### PR TITLE
Comprimi le foto lato client prima di inviarle all'assistente

### DIFF
--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -43,9 +43,11 @@ esistente, non verrà deployato da qui.
   usato per leggere/scrivere `docs/data/*.json`) come `Authorization: Bearer`.
   Il Worker lo valida chiamando `GET https://api.github.com/user` prima di
   autorizzare la chiamata a pagamento verso Anthropic.
-- Le foto per la valutazione salute pianta sono limitate a 5MB lato client
-  (`docs/js/agente.js`); non serve una configurazione aggiuntiva sul Worker,
-  ma tienilo presente se cambi quel limite.
+- Le foto per la valutazione salute pianta vengono ridimensionate/compresse
+  lato client (`resizeImageForAgente` in `docs/js/agente.js`, max 1568px sul
+  lato lungo, JPEG qualità 0.85) prima dell'invio, così anche gli scatti da
+  smartphone (spesso 8-15MB) arrivano al Worker già leggeri; non serve alcuna
+  configurazione aggiuntiva sul Worker per gestirle.
 - Finché questo endpoint non è distribuito, `docs/agente.html` resta
   utilizzabile: l'azione "Cosa fare oggi" funziona comunque (non chiama il
   Worker), mentre chat libera e valutazione salute mostreranno un errore

--- a/docs/js/agente.js
+++ b/docs/js/agente.js
@@ -10,7 +10,11 @@ function getParam(name) {
 }
 
 const WORKER_CHAT_URL = "https://giardino.robertagenovese.workers.dev/agente/chat";
-const MAX_FOTO_BYTES = 5 * 1024 * 1024;
+// Limite solo di buon senso sul file originale scelto dall'utente: la foto
+// viene comunque ridimensionata/compressa prima dell'invio (vedi
+// resizeImageForAgente), quindi le foto scattate da smartphone (spesso 8-15MB)
+// non vengono più rifiutate.
+const MAX_FOTO_BYTES_ORIGINALE = 25 * 1024 * 1024;
 
 let chatHistory = [];
 
@@ -21,6 +25,54 @@ function appendBubble(role, text) {
   bubble.textContent = text;
   win.appendChild(bubble);
   win.scrollTop = win.scrollHeight;
+}
+
+// Ridimensiona/comprime la foto lato client prima di inviarla al Worker:
+// le foto da smartphone spesso superano i 5-15MB, ben oltre quanto serve
+// per l'analisi visiva (Claude ridimensiona comunque le immagini oltre
+// ~1568px sul lato lungo) e oltre i limiti pratici di dimensione richiesta.
+function resizeImageForAgente(file, maxDim = 1568, quality = 0.85) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+
+      let { width, height } = img;
+      if (width > maxDim || height > maxDim) {
+        const scale = maxDim / Math.max(width, height);
+        width = Math.round(width * scale);
+        height = Math.round(height * scale);
+      }
+
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      canvas.getContext("2d").drawImage(img, 0, 0, width, height);
+
+      canvas.toBlob(blob => {
+        if (!blob) {
+          reject(new Error("Impossibile comprimere la foto."));
+          return;
+        }
+        const reader = new FileReader();
+        reader.onerror = () => reject(new Error("Errore nella lettura della foto compressa."));
+        reader.onload = () => resolve({
+          mediaType: "image/jpeg",
+          data: (reader.result || "").split(",")[1] || ""
+        });
+        reader.readAsDataURL(blob);
+      }, "image/jpeg", quality);
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error("Impossibile leggere la foto selezionata."));
+    };
+
+    img.src = objectUrl;
+  });
 }
 
 function stripHtml(html) {
@@ -122,8 +174,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       return;
     }
 
-    if (file.size > MAX_FOTO_BYTES) {
-      alert("La foto è troppo grande (limite 5MB).");
+    if (file.size > MAX_FOTO_BYTES_ORIGINALE) {
+      alert("La foto è troppo grande (limite 25MB).");
       e.target.value = "";
       preview.innerHTML = "";
       fotoFile = null;
@@ -215,15 +267,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const btn = document.getElementById("salute-invia");
     btn.disabled = true;
-    btn.textContent = "Invio in corso...";
+    btn.textContent = "Comprimo la foto...";
 
     try {
-      const base64 = await new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onerror = () => reject(new Error("Errore nella lettura della foto."));
-        reader.onload = () => resolve((reader.result || "").split(",")[1] || "");
-        reader.readAsDataURL(fotoFile);
-      });
+      const { mediaType, data: base64 } = await resizeImageForAgente(fotoFile);
+
+      btn.textContent = "Invio in corso...";
 
       if (document.getElementById("salute-salva-galleria").checked) {
         const token = localStorage.getItem("github_token");
@@ -245,7 +294,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       const reply = await inviaAlWorker({
         message: "Valuta lo stato di salute di questa pianta a partire dalla foto allegata, tenendo conto del contesto fornito.",
         context: contesto,
-        image: { mediaType: fotoFile.type, data: base64 }
+        image: { mediaType, data: base64 }
       });
 
       appendBubble("assistant", reply);


### PR DESCRIPTION
## Summary

Le foto scattate da smartphone (spesso 8-15MB) venivano rifiutate dal limite fisso di 5MB nella pagina Assistente (`agente.html`), impedendo di fatto l'uso della valutazione salute pianta da mobile.

## Key Changes

- Aggiunta `resizeImageForAgente()` in `docs/js/agente.js`: ridimensiona la foto via canvas (max 1568px sul lato lungo, JPEG qualità 0.85) prima di inviarla al Worker per l'analisi.
- Il limite sul file originale è ora un controllo di buon senso a 25MB (prima 5MB), dato che la compressione avviene comunque prima dell'invio.
- Il salvataggio opzionale in galleria continua a usare il file originale a piena qualità: solo la copia inviata all'assistente viene compressa.
- Aggiornato `cloudflare-worker/README.md` per riflettere il nuovo comportamento.

## Test plan

Verificato in locale con browser headless e una foto sintetica di 13.6MB: dopo la compressione arriva al Worker a ~0.7MB, la risposta dell'assistente viene mostrata correttamente, nessun errore in console.

- [ ] Riprovare la valutazione salute pianta da smartphone con una foto reale


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_