### PR TITLE
Risolve conflitti di scrittura concorrente su GitHub Contents API

### DIFF
--- a/src/composables/useApi.js
+++ b/src/composables/useApi.js
@@ -17,35 +17,57 @@ function getHeaders() {
 
 export function useApi() {
 
-  async function saveJSON(filename, data) {
+  // dataOrUpdater può essere:
+  // - un oggetto già pronto da scrivere (comportamento storico)
+  // - una funzione (contenutoAttuale) => nuovoContenuto: viene chiamata con il
+  //   contenuto RIMOSSO più recente letto da GitHub subito prima di scrivere,
+  //   e se GitHub rifiuta il PUT per conflitto di SHA (qualcun altro ha
+  //   scritto lo stesso file nel frattempo — un altro tab/dispositivo, o la
+  //   sessione Claude Code che elabora la coda), la funzione viene richiamata
+  //   di nuovo sul contenuto aggiornato invece di fallire subito. Ritorna i
+  //   dati effettivamente scritti, così il chiamante può allineare lo store
+  //   locale allo stato reale (non a quello, potenzialmente superato, con cui
+  //   aveva calcolato la modifica).
+  async function saveJSON(filename, dataOrUpdater, { retries = 4 } = {}) {
     const path = `public/data/${filename}`
     const url  = `https://api.github.com/repos/${OWNER}/${REPO}/contents/${path}`
+    const isUpdater = typeof dataOrUpdater === 'function'
 
-    // Ottieni SHA attuale (null se il file non esiste ancora)
-    let sha
-    const info = await fetch(url, { headers: getHeaders() })
-    if (info.ok) {
-      sha = (await info.json()).sha
-    } else if (info.status !== 404) {
-      throw new Error(`Errore lettura file: ${info.status}`)
-    }
-    // Se 404 → sha rimane undefined → GitHub crea il file
+    for (let tentativo = 0; ; tentativo++) {
+      // Ottieni SHA e contenuto attuali (null/undefined se il file non esiste ancora)
+      let sha
+      let corrente = null
+      const info = await fetch(url, { headers: getHeaders() })
+      if (info.ok) {
+        const json = await info.json()
+        sha = json.sha
+        corrente = JSON.parse(decodeURIComponent(escape(atob(json.content))))
+      } else if (info.status !== 404) {
+        throw new Error(`Errore lettura file: ${info.status}`)
+      }
+      // Se 404 → sha rimane undefined → GitHub crea il file
 
-    const content = btoa(unescape(encodeURIComponent(JSON.stringify(data, null, 2))))
+      const data = isUpdater ? dataOrUpdater(corrente) : dataOrUpdater
+      const content = btoa(unescape(encodeURIComponent(JSON.stringify(data, null, 2))))
 
-    const body = { message: `Aggiorna ${filename}`, content, branch: BRANCH }
-    if (sha) body.sha = sha
+      const body = { message: `Aggiorna ${filename}`, content, branch: BRANCH }
+      if (sha) body.sha = sha
 
-    const res = await fetch(url, {
-      method: 'PUT',
-      headers: getHeaders(),
-      body: JSON.stringify(body),
-    })
-    if (!res.ok) {
-      const err = await res.json()
+      const res = await fetch(url, {
+        method: 'PUT',
+        headers: getHeaders(),
+        body: JSON.stringify(body),
+      })
+      if (res.ok) return data
+
+      const err = await res.json().catch(() => ({}))
+      const conflitto = res.status === 409 || /does not match/.test(err.message || '')
+      // Riprova solo se abbiamo una funzione di aggiornamento: con un oggetto
+      // fisso, ripetere la stessa scrittura rischierebbe di sovrascrivere una
+      // modifica concorrente invece di combinarsi con essa.
+      if (conflitto && isUpdater && tentativo < retries) continue
       throw new Error(err.message || `Errore salvataggio ${filename}`)
     }
-    return res.json()
   }
 
   async function uploadFile(repoPath, base64Content, message = 'Upload file') {

--- a/src/composables/useApi.js
+++ b/src/composables/useApi.js
@@ -41,7 +41,9 @@ export function useApi() {
       if (info.ok) {
         const json = await info.json()
         sha = json.sha
-        corrente = JSON.parse(decodeURIComponent(escape(atob(json.content))))
+        // L'API GitHub restituisce il base64 con newline ogni 76 caratteri:
+        // atob() lancia un'eccezione se non vengono rimossi prima.
+        corrente = JSON.parse(decodeURIComponent(escape(atob(json.content.replace(/\s/g, '')))))
       } else if (info.status !== 404) {
         throw new Error(`Errore lettura file: ${info.status}`)
       }

--- a/src/views/AgenteView.vue
+++ b/src/views/AgenteView.vue
@@ -199,8 +199,8 @@ async function aggiungiRichiesta() {
   errore.value = null
   try {
     const id = `r-${Date.now()}-${Math.random().toString(36).slice(2,6)}`
-    const nuove = {
-      ...raw.value,
+    const nuove = await saveJSON('richieste-agente.json', (correnti) => ({
+      ...(correnti ?? raw.value),
       [id]: {
         tipo: nuovoTipo.value,
         messaggio: nuovoMessaggio.value.trim(),
@@ -209,8 +209,7 @@ async function aggiungiRichiesta() {
         creata: new Date().toISOString(),
         risposta: null,
       }
-    }
-    await saveJSON('richieste-agente.json', nuove)
+    }))
     raw.value = nuove
     nuovoMessaggio.value = ''
     fotoBase64.value  = null

--- a/src/views/AttivitaView.vue
+++ b/src/views/AttivitaView.vue
@@ -101,15 +101,17 @@ async function registra(item) {
   if (salvando.value || salvandoGruppo.value) return
   salvando.value = item.key
   try {
-    const nuove = { ...store.piante }
-    nuove[item.piantaId] = {
-      ...nuove[item.piantaId],
-      ultima_cura: {
-        ...nuove[item.piantaId].ultima_cura,
-        [item.tipo]: new Date().toISOString().split('T')[0],
+    const nuove = await saveJSON('piante.json', (correnti) => {
+      const base = { ...(correnti ?? store.piante) }
+      base[item.piantaId] = {
+        ...base[item.piantaId],
+        ultima_cura: {
+          ...base[item.piantaId].ultima_cura,
+          [item.tipo]: new Date().toISOString().split('T')[0],
+        }
       }
-    }
-    await saveJSON('piante.json', nuove)
+      return base
+    })
     store.piante = nuove
   } finally {
     salvando.value = null
@@ -120,15 +122,17 @@ async function registraGruppo(gruppo) {
   if (salvandoGruppo.value || salvando.value) return
   salvandoGruppo.value = gruppo.chiave
   try {
-    const nuove = { ...store.piante }
     const oggi = new Date().toISOString().split('T')[0]
-    for (const item of gruppo.items) {
-      nuove[item.piantaId] = {
-        ...nuove[item.piantaId],
-        ultima_cura: { ...nuove[item.piantaId].ultima_cura, [item.tipo]: oggi },
+    const nuove = await saveJSON('piante.json', (correnti) => {
+      const base = { ...(correnti ?? store.piante) }
+      for (const item of gruppo.items) {
+        base[item.piantaId] = {
+          ...base[item.piantaId],
+          ultima_cura: { ...base[item.piantaId].ultima_cura, [item.tipo]: oggi },
+        }
       }
-    }
-    await saveJSON('piante.json', nuove)
+      return base
+    })
     store.piante = nuove
   } finally {
     salvandoGruppo.value = null

--- a/src/views/AttivitaView.vue
+++ b/src/views/AttivitaView.vue
@@ -103,10 +103,11 @@ async function registra(item) {
   try {
     const nuove = await saveJSON('piante.json', (correnti) => {
       const base = { ...(correnti ?? store.piante) }
+      const piantaEsistente = base[item.piantaId] || {}
       base[item.piantaId] = {
-        ...base[item.piantaId],
+        ...piantaEsistente,
         ultima_cura: {
-          ...base[item.piantaId].ultima_cura,
+          ...(piantaEsistente.ultima_cura || {}),
           [item.tipo]: new Date().toISOString().split('T')[0],
         }
       }
@@ -126,9 +127,10 @@ async function registraGruppo(gruppo) {
     const nuove = await saveJSON('piante.json', (correnti) => {
       const base = { ...(correnti ?? store.piante) }
       for (const item of gruppo.items) {
+        const piantaEsistente = base[item.piantaId] || {}
         base[item.piantaId] = {
-          ...base[item.piantaId],
-          ultima_cura: { ...base[item.piantaId].ultima_cura, [item.tipo]: oggi },
+          ...piantaEsistente,
+          ultima_cura: { ...(piantaEsistente.ultima_cura || {}), [item.tipo]: oggi },
         }
       }
       return base

--- a/src/views/EditPiantaView.vue
+++ b/src/views/EditPiantaView.vue
@@ -108,15 +108,16 @@ async function salva() {
   try {
     const nuove = await saveJSON('piante.json', (correnti) => {
       const base = { ...(correnti ?? store.piante) }
+      const piantaEsistente = isNuova.value ? {} : (base[id] || {})
       base[id] = {
-        ...(isNuova.value ? {} : base[id]),
+        ...piantaEsistente,
         specie:    form.value.specie,
         zona:      form.value.zona,
         sottozona: form.value.sottozona || null,
         varieta:   form.value.varieta  || '',
         impianto:  form.value.impianto || '',
         note:      form.value.note     || '',
-        ...( isNuova.value ? { ultima_cura: {} } : {} ),
+        ultima_cura: piantaEsistente.ultima_cura || {},
       }
       return base
     })

--- a/src/views/EditPiantaView.vue
+++ b/src/views/EditPiantaView.vue
@@ -104,20 +104,22 @@ onMounted(async () => {
 async function salva() {
   if (!form.value.specie || !form.value.zona || salvando.value) return
   salvando.value = true
+  const id = isNuova.value ? `${form.value.specie}-${Date.now()}` : route.params.id
   try {
-    const nuove = { ...store.piante }
-    const id = isNuova.value ? `${form.value.specie}-${Date.now()}` : route.params.id
-    nuove[id] = {
-      ...(isNuova.value ? {} : nuove[id]),
-      specie:    form.value.specie,
-      zona:      form.value.zona,
-      sottozona: form.value.sottozona || null,
-      varieta:   form.value.varieta  || '',
-      impianto:  form.value.impianto || '',
-      note:      form.value.note     || '',
-      ...( isNuova.value ? { ultima_cura: {} } : {} ),
-    }
-    await saveJSON('piante.json', nuove)
+    const nuove = await saveJSON('piante.json', (correnti) => {
+      const base = { ...(correnti ?? store.piante) }
+      base[id] = {
+        ...(isNuova.value ? {} : base[id]),
+        specie:    form.value.specie,
+        zona:      form.value.zona,
+        sottozona: form.value.sottozona || null,
+        varieta:   form.value.varieta  || '',
+        impianto:  form.value.impianto || '',
+        note:      form.value.note     || '',
+        ...( isNuova.value ? { ultima_cura: {} } : {} ),
+      }
+      return base
+    })
     store.piante = nuove
     router.push(isNuova.value ? '/piante' : `/piante/${id}`)
   } finally {

--- a/src/views/EditZonaView.vue
+++ b/src/views/EditZonaView.vue
@@ -84,18 +84,20 @@ onMounted(async () => {
 async function salva() {
   if (!form.value.nome.trim() || salvando.value) return
   salvando.value = true
+  const key = isNuova.value ? form.value.nome.trim() : route.params.zona
   try {
-    const nuove = { ...store.zone }
-    const key   = isNuova.value ? form.value.nome.trim() : route.params.zona
-    nuove[key] = {
-      ...(isNuova.value ? {} : nuove[key]),
-      nome:        form.value.nome.trim(),
-      tipo:        form.value.tipo,
-      descrizione: form.value.descrizione.trim() || '',
-      microclima:  form.value.microclima.trim()  || '',
-      esposizione: form.value.esposizione,
-    }
-    await saveJSON('zone.json', nuove)
+    const nuove = await saveJSON('zone.json', (correnti) => {
+      const base = { ...(correnti ?? store.zone) }
+      base[key] = {
+        ...(isNuova.value ? {} : base[key]),
+        nome:        form.value.nome.trim(),
+        tipo:        form.value.tipo,
+        descrizione: form.value.descrizione.trim() || '',
+        microclima:  form.value.microclima.trim()  || '',
+        esposizione: form.value.esposizione,
+      }
+      return base
+    })
     store.zone = nuove
     router.push('/zone')
   } finally {

--- a/src/views/PiantaView.vue
+++ b/src/views/PiantaView.vue
@@ -161,10 +161,11 @@ async function registraCura(tipo) {
   try {
     const nuove = await saveJSON('piante.json', (correnti) => {
       const base = { ...(correnti ?? store.piante) }
+      const piantaEsistente = base[id] || {}
       base[id] = {
-        ...base[id],
+        ...piantaEsistente,
         ultima_cura: {
-          ...base[id].ultima_cura,
+          ...(piantaEsistente.ultima_cura || {}),
           [tipo]: new Date().toISOString().split('T')[0],
         }
       }

--- a/src/views/PiantaView.vue
+++ b/src/views/PiantaView.vue
@@ -157,16 +157,19 @@ const cureUrgenti = computed(() =>
 async function registraCura(tipo) {
   if (!pianta.value || salvando.value) return
   salvando.value = tipo
+  const id = pianta.value.id
   try {
-    const nuove = { ...store.piante }
-    nuove[pianta.value.id] = {
-      ...nuove[pianta.value.id],
-      ultima_cura: {
-        ...nuove[pianta.value.id].ultima_cura,
-        [tipo]: new Date().toISOString().split('T')[0],
+    const nuove = await saveJSON('piante.json', (correnti) => {
+      const base = { ...(correnti ?? store.piante) }
+      base[id] = {
+        ...base[id],
+        ultima_cura: {
+          ...base[id].ultima_cura,
+          [tipo]: new Date().toISOString().split('T')[0],
+        }
       }
-    }
-    await saveJSON('piante.json', nuove)
+      return base
+    })
     store.piante = nuove
   } finally {
     salvando.value = null
@@ -176,10 +179,13 @@ async function registraCura(tipo) {
 async function eliminaPianta() {
   if (!pianta.value) return
   eliminando.value = true
+  const id = pianta.value.id
   try {
-    const nuove = { ...store.piante }
-    delete nuove[pianta.value.id]
-    await saveJSON('piante.json', nuove)
+    const nuove = await saveJSON('piante.json', (correnti) => {
+      const base = { ...(correnti ?? store.piante) }
+      delete base[id]
+      return base
+    })
     store.piante = nuove
     router.push('/piante')
   } finally {

--- a/src/views/PianteView.vue
+++ b/src/views/PianteView.vue
@@ -130,10 +130,13 @@ function avviaElimina(pianta) {
 async function eliminaPianta() {
   if (!daEliminare.value) return
   eliminando.value = true
+  const id = daEliminare.value.id
   try {
-    const nuove = { ...store.piante }
-    delete nuove[daEliminare.value.id]
-    await saveJSON('piante.json', nuove)
+    const nuove = await saveJSON('piante.json', (correnti) => {
+      const base = { ...(correnti ?? store.piante) }
+      delete base[id]
+      return base
+    })
     store.piante = nuove
     daEliminare.value = null
   } finally {

--- a/src/views/ProgettiView.vue
+++ b/src/views/ProgettiView.vue
@@ -89,10 +89,10 @@ function badgeStato(stato) {
 async function salvaProgetto() {
   if (!form.value.titolo.trim() || salvando.value) return
   salvando.value = true
+  const id = `progetto-${Date.now()}`
   try {
-    const id = `progetto-${Date.now()}`
-    const nuovi = {
-      ...store.progetti,
+    const nuovi = await saveJSON('progetti.json', (correnti) => ({
+      ...(correnti ?? store.progetti),
       [id]: {
         titolo: form.value.titolo.trim(),
         descrizione: form.value.descrizione.trim() || null,
@@ -101,8 +101,7 @@ async function salvaProgetto() {
         stato: 'bozza',
         creato: new Date().toISOString().split('T')[0],
       }
-    }
-    await saveJSON('progetti.json', nuovi)
+    }))
     store.progetti = nuovi
     mostraForm.value = false
     form.value = { titolo: '', descrizione: '', zona: '', scadenza: '' }

--- a/src/views/SottozoneView.vue
+++ b/src/views/SottozoneView.vue
@@ -86,20 +86,22 @@ async function salva() {
   if (!form.value.nome.trim() || salvando.value) return
   salvando.value = true
   try {
-    const nuove = { ...store.sottozone }
-    nuove[route.params.zona] = {
-      ...(nuove[route.params.zona] ?? {}),
-      [form.value.nome]: {
-        nome:        form.value.nome.trim(),
-        descrizione: form.value.descrizione.trim() || '',
-        tipo:        form.value.tipo,
-        esposizione: [],
-        microclima:  '',
-        criticita:   '',
-        manutenzione:'',
+    const nuove = await saveJSON('sottozone.json', (correnti) => {
+      const base = { ...(correnti ?? store.sottozone) }
+      base[route.params.zona] = {
+        ...(base[route.params.zona] ?? {}),
+        [form.value.nome]: {
+          nome:        form.value.nome.trim(),
+          descrizione: form.value.descrizione.trim() || '',
+          tipo:        form.value.tipo,
+          esposizione: [],
+          microclima:  '',
+          criticita:   '',
+          manutenzione:'',
+        }
       }
-    }
-    await saveJSON('sottozone.json', nuove)
+      return base
+    })
     store.sottozone = nuove
     mostraForm.value = false
     form.value = { nome: '', descrizione: '', tipo: 'esterno' }

--- a/src/views/ZoneView.vue
+++ b/src/views/ZoneView.vue
@@ -91,17 +91,22 @@ function contaPiante(zonaKey) {
 async function eliminaZona() {
   if (!daEliminare.value) return
   eliminando.value = true
+  const zonaKey = daEliminare.value
   try {
-    const nuoveZone = { ...store.zone }
-    delete nuoveZone[daEliminare.value]
-    await saveJSON('zone.json', nuoveZone)
+    const nuoveZone = await saveJSON('zone.json', (correnti) => {
+      const base = { ...(correnti ?? store.zone) }
+      delete base[zonaKey]
+      return base
+    })
     store.zone = nuoveZone
 
     // Elimina sottozone collegate
-    if (store.sottozone?.[daEliminare.value]) {
-      const nuoveSottozone = { ...store.sottozone }
-      delete nuoveSottozone[daEliminare.value]
-      await saveJSON('sottozone.json', nuoveSottozone)
+    if (store.sottozone?.[zonaKey]) {
+      const nuoveSottozone = await saveJSON('sottozone.json', (correnti) => {
+        const base = { ...(correnti ?? store.sottozone) }
+        delete base[zonaKey]
+        return base
+      })
       store.sottozone = nuoveSottozone
     }
     daEliminare.value = null


### PR DESCRIPTION
## Summary

Segnalato in console: `Error: public/data/piante.json does not match <sha>` (ripetuto due volte).

## Causa

`piante.json` viene scritto da 8 punti diversi dell'app (AttivitaView x2, PiantaView x2, EditPiantaView, PianteView, oltre a ZoneView/SottozoneView/EditZonaView per gli altri file dati). `saveJSON()` in `useApi.js` legge lo SHA attuale e poi fa il PUT: se un'altra scrittura (altro tab/dispositivo aperto, o un'azione bulk e una individuale quasi simultanee) si inserisce tra la lettura e la scrittura, GitHub rifiuta il PUT con un conflitto 409 — e l'app si limitava a mostrare l'errore in console senza alcun recupero.

## Fix

`saveJSON(filename, dataOrUpdater)` ora accetta anche una **funzione di aggiornamento** `(contenutoAttuale) => nuovoContenuto`, oltre al vecchio oggetto già pronto:

- Se riceve una funzione, in caso di conflitto (409) rilegge il contenuto più recente da GitHub e la richiama su quello (fino a 4 tentativi), invece di fallire subito.
- Con un oggetto fisso il comportamento resta quello di prima (nessun retry automatico, per non rischiare di sovrascrivere ciecamente una modifica concorrente).
- Ritorna i dati effettivamente scritti, così i chiamanti allineano lo store locale allo stato reale invece che alla base con cui avevano calcolato la modifica.

Tutti i punti di chiamata (`AttivitaView`, `PiantaView`, `EditPiantaView`, `PianteView`, `ProgettiView`, `SottozoneView`, `ZoneView`, `EditZonaView`, `AgenteView`) sono stati aggiornati per passare una funzione invece di un oggetto precalcolato.

## Test plan

- [x] Test isolato di `useApi.js` (simulando fetch/PUT): un conflitto 409 seguito da successo preserva la modifica concorrente E applica quella del chiamante, con lo SHA aggiornato al secondo tentativo — verificato con script Node dedicato.
- [x] `npm run build` completa senza errori.
- [ ] Riprovare in produzione con due tab aperti contemporaneamente su un'azione "Fatto"/bulk per confermare che non compaia più l'errore.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_