### PR TITLE
Ripristina il raggruppamento per sottozona nella lista Piante

### DIFF
--- a/src/views/PianteView.vue
+++ b/src/views/PianteView.vue
@@ -52,7 +52,7 @@
         </div>
         <template v-else>
           <template v-for="gruppo in gruppiPiante" :key="gruppo.chiave">
-            <p class="section-label" style="margin-top:16px;">📍 {{ gruppo.sottozona ?? gruppo.zona }}</p>
+            <p class="section-label" style="margin-top:16px;">📍 {{ gruppo.sottozona ? (filtroZona === 'tutte' ? gruppo.zona + ' - ' + gruppo.sottozona : gruppo.sottozona) : gruppo.zona }}</p>
             <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:8px;">
               <PiantaRiga v-for="p in gruppo.items" :key="p.id" :pianta="p"
                 @elimina="avviaElimina(p)" />
@@ -144,7 +144,16 @@ const gruppiPiante = computed(() => {
     if (!gruppi.has(chiave)) gruppi.set(chiave, { chiave, zona: p.zona, sottozona: p.sottozona, items: [] })
     gruppi.get(chiave).items.push(p)
   }
-  return [...gruppi.values()]
+  // Ordine deterministico (alfabetico zona poi sottozona): pianteFiltrate può
+  // essere ordinata per urgenza, che cambia nel tempo e farebbe "saltare" i
+  // gruppi in giro a ogni variazione di stato invece di restare stabili.
+  return [...gruppi.values()].sort((a, b) => {
+    const ordZona = a.zona.localeCompare(b.zona)
+    if (ordZona !== 0) return ordZona
+    if (!a.sottozona) return -1
+    if (!b.sottozona) return 1
+    return a.sottozona.localeCompare(b.sottozona)
+  })
 })
 
 function avviaElimina(pianta) {

--- a/src/views/PianteView.vue
+++ b/src/views/PianteView.vue
@@ -44,11 +44,22 @@
         <p class="section-label">Tutte le piante</p>
       </template>
 
-      <!-- Lista principale -->
-      <div v-if="pianteFiltrate.length" style="display:flex;flex-direction:column;gap:8px;">
-        <PiantaRiga v-for="p in pianteFiltrate" :key="p.id" :pianta="p"
-          @elimina="avviaElimina(p)" />
-      </div>
+      <!-- Lista principale: raggruppata per sottozona (o zona) quando non si sta cercando -->
+      <template v-if="pianteFiltrate.length">
+        <div v-if="cerca.trim()" style="display:flex;flex-direction:column;gap:8px;">
+          <PiantaRiga v-for="p in pianteFiltrate" :key="p.id" :pianta="p"
+            @elimina="avviaElimina(p)" />
+        </div>
+        <template v-else>
+          <template v-for="gruppo in gruppiPiante" :key="gruppo.chiave">
+            <p class="section-label" style="margin-top:16px;">📍 {{ gruppo.sottozona ?? gruppo.zona }}</p>
+            <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:8px;">
+              <PiantaRiga v-for="p in gruppo.items" :key="p.id" :pianta="p"
+                @elimina="avviaElimina(p)" />
+            </div>
+          </template>
+        </template>
+      </template>
 
       <!-- Stato vuoto -->
       <div v-else style="text-align:center;padding:48px 20px;color:var(--ink-faint);">
@@ -122,6 +133,19 @@ const pianteFiltrate = computed(() => {
 const pianteUrgenti = computed(() =>
   piante.value.filter(p => p.urgente && (filtroZona.value === 'tutte' || p.zona === filtroZona.value))
 )
+
+// Raggruppa la lista principale per sottozona (o per zona, se la pianta non
+// ne ha una): comportamento della vecchia webapp, dove le piante erano
+// sempre organizzate sotto l'intestazione della propria sottozona/zona.
+const gruppiPiante = computed(() => {
+  const gruppi = new Map()
+  for (const p of pianteFiltrate.value) {
+    const chiave = p.sottozona ? `${p.zona}|${p.sottozona}` : p.zona
+    if (!gruppi.has(chiave)) gruppi.set(chiave, { chiave, zona: p.zona, sottozona: p.sottozona, items: [] })
+    gruppi.get(chiave).items.push(p)
+  }
+  return [...gruppi.values()]
+})
 
 function avviaElimina(pianta) {
   daEliminare.value = pianta


### PR DESCRIPTION
## Summary

Richiesto: nella vecchia webapp (Jekyll, `docs/js/piante.js`) sotto l'elenco delle zone le piante erano raggruppate per sottozona; il rifacimento Vue mostrava solo una lista piatta filtrabile per zona, senza raggruppamento.

## Fix

Aggiunto in `PianteView.vue` il computed `gruppiPiante`, che raggruppa l'elenco filtrato per `zona|sottozona` (stesso pattern di `raggruppaPerZona` già usato in Attività) e mostra un'intestazione "📍 sottozona" (o il nome della zona, se la pianta non ha sottozona) sopra ciascun gruppo. Il raggruppamento si applica alla lista principale; durante una ricerca testuale resta invece una lista piatta ordinata per urgenza, per non aggiungere intestazioni poco utili sui risultati di ricerca.

## Test plan

- [x] `npm run build` completa senza errori.
- [x] Verificato con Playwright su dati reali (83 piante, 6 zone): il raggruppamento compare correttamente su "tutte le piante" e quando si filtra per una singola zona (es. "Casa" → Bagni, Cucina, Soggiorno, Camera di Marta, Scalinata); la ricerca testuale resta piatta senza intestazioni.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_