### PR TITLE
Aggiunge le piante nei vasetti in Casa/Soggiorno

### DIFF
--- a/public/data/piante.json
+++ b/public/data/piante.json
@@ -1150,5 +1150,53 @@
       "irrigazione": "2026-07-20",
       "concimazione": "2026-07-20"
     }
+  },
+  "echeveria-1784550000101": {
+    "specie": "echeveria",
+    "zona": "Casa",
+    "sottozona": "Soggiorno",
+    "varieta": "",
+    "impianto": "2026-07-20",
+    "note": "Rosetta blu-verde compatta nel vaso a forma di gatto (giallo), sul davanzale del soggiorno. Identificata il 20/07/2026 dall'assistente AI a partire da una foto.",
+    "ultima_cura": {
+      "irrigazione": "2026-07-20",
+      "concimazione": "2026-07-20"
+    }
+  },
+  "sedum-morganianum-1784550000102": {
+    "specie": "sedum-morganianum",
+    "zona": "Casa",
+    "sottozona": "Soggiorno",
+    "varieta": "",
+    "impianto": "2026-07-20",
+    "note": "Succulenta ricadente con foglioline tonde a grappolo nel vaso coniglio bianco, sul davanzale del soggiorno. Identificata il 20/07/2026 dall'assistente AI a partire da una foto.",
+    "ultima_cura": {
+      "irrigazione": "2026-07-20",
+      "concimazione": "2026-07-20"
+    }
+  },
+  "echeveria-1784550000103": {
+    "specie": "echeveria",
+    "zona": "Casa",
+    "sottozona": "Soggiorno",
+    "varieta": "",
+    "impianto": "2026-07-20",
+    "note": "Piccola rosetta giovane grigio-verde nel vaso coniglio crema, sul davanzale del soggiorno. Specie non certa a questo stadio (possibile Graptopetalum paraguayense). Identificata il 20/07/2026 dall'assistente AI a partire da una foto.",
+    "ultima_cura": {
+      "irrigazione": "2026-07-20",
+      "concimazione": "2026-07-20"
+    }
+  },
+  "mammillaria-1784550000104": {
+    "specie": "mammillaria",
+    "zona": "Casa",
+    "sottozona": "Soggiorno",
+    "varieta": "",
+    "impianto": "2026-07-20",
+    "note": "Cactus globoso con spine bianche raggiate a stella, nel vaso in terracotta sul davanzale del soggiorno. Identificata il 20/07/2026 dall'assistente AI a partire da una foto.",
+    "ultima_cura": {
+      "irrigazione": "2026-07-20",
+      "concimazione": "2026-07-20"
+    }
   }
 }

--- a/public/data/specie.json
+++ b/public/data/specie.json
@@ -2898,5 +2898,41 @@
         "inverno": "nessuna"
       }
     }
+  },
+  "sedum-morganianum": {
+    "nome": "Sedum morganianum",
+    "specie": "Sedum morganianum / burrito",
+    "descrizione": "<p>Succulenta ricadente con foglioline tonde e carnose disposte a grappolo su fusti pendenti, ideale per vasi sospesi o davanzali.</p>",
+    "esigenze": {
+      "luce": "Molto luminosa, sole diretto alcune ore",
+      "acqua": "Scarsa",
+      "terreno": "Molto drenante"
+    },
+    "alert": [
+      "le foglie si staccano facilmente al tocco: maneggiare con cura",
+      "evitare assolutamente ristagni idrici",
+      "se etiola (fusti allungati e radi) → luce insufficiente",
+      "foglie rugose e svuotate → sete prolungata"
+    ],
+    "manutenzione": {
+      "irrigazione": {
+        "primavera": "ogni 10-14 giorni",
+        "estate": "ogni 7-10 giorni",
+        "autunno": "ogni 14-20 giorni",
+        "inverno": "ogni 20-30 giorni"
+      },
+      "concimazione": {
+        "primavera": "una volta al mese con concime leggero per succulente",
+        "estate": "una volta al mese",
+        "autunno": "sospesa",
+        "inverno": "sospesa"
+      },
+      "potatura": {
+        "primavera": "nessuna",
+        "estate": "nessuna",
+        "autunno": "nessuna",
+        "inverno": "nessuna"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Aggiunge in `piante.json` le 4 piante identificate dalla foto dei vasetti decorativi sul davanzale del soggiorno (richiesta `r-1784539667885-0q1w`): Echeveria (vaso gatto giallo), Sedum ricadente (vaso coniglio bianco), Echeveria/Graptopetalum giovane con ID incerta (vaso coniglio crema), Mammillaria (vaso in terracotta)
- Aggiunge in `specie.json` il nuovo profilo `sedum-morganianum` (Sedum morganianum / burrito), non ancora presente nel catalogo, con indicazioni di luce, irrigazione e concimazione coerenti con le altre succulente già schedate

## Test plan
- [x] Verificato che entrambi i JSON risultanti siano validi (`jq` parse OK)
- [x] Verificato che le piante già esistenti nella zona Casa/Soggiorno non siano state duplicate


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4aQMagxU1bcgqwt1fHpp)_