### PR TITLE
Aggiunge la Gasteria in Casa/Soggiorno

### DIFF
--- a/public/data/piante.json
+++ b/public/data/piante.json
@@ -1198,5 +1198,17 @@
       "irrigazione": "2026-07-20",
       "concimazione": "2026-07-20"
     }
+  },
+  "gasteria-1784541281856": {
+    "specie": "gasteria",
+    "zona": "Casa",
+    "sottozona": "Soggiorno",
+    "varieta": "",
+    "impianto": "2026-07-20",
+    "note": "Foglie carnose bruno-violacee a ventaglio in vaso di terracotta con ciottoli decorativi. Identificata il 20/07/2026 dall'assistente AI a partire da una foto (inizialmente ipotizzata come Sansevieria in sofferenza, poi corretta in Gasteria dopo segnalazione dell'utente). Controllare che la base delle foglie a contatto con i ciottoli resti soda.",
+    "ultima_cura": {
+      "irrigazione": "2026-07-20",
+      "concimazione": "2026-07-20"
+    }
   }
 }

--- a/public/data/specie.json
+++ b/public/data/specie.json
@@ -2934,5 +2934,41 @@
         "inverno": "nessuna"
       }
     }
+  },
+  "gasteria": {
+    "nome": "Gasteria",
+    "specie": "Gasteria spp.",
+    "descrizione": "<p>Succulenta a foglie carnose disposte a ventaglio, superficie maculata di punti chiari su fondo scuro; tollera bene la luce indiretta.</p>",
+    "esigenze": {
+      "luce": "Luminosa, sole diretto solo filtrato",
+      "acqua": "Scarsa",
+      "terreno": "Molto drenante"
+    },
+    "alert": [
+      "a differenza di altre succulente tollera bene la luce indiretta: evitare sole diretto nelle ore più calde (rischio scottature)",
+      "colorazione bronzo/porpora intensa è normale risposta a luce forte o freddo, non segno di malattia",
+      "evitare ristagni idrici, soprattutto se ciottoli decorativi sono a contatto con la base delle foglie",
+      "base molle o scura → marciume, intervenire subito"
+    ],
+    "manutenzione": {
+      "irrigazione": {
+        "primavera": "ogni 14-20 giorni",
+        "estate": "ogni 10-14 giorni",
+        "autunno": "ogni 20-25 giorni",
+        "inverno": "ogni 30 giorni"
+      },
+      "concimazione": {
+        "primavera": "una volta al mese con concime leggero per succulente",
+        "estate": "una volta al mese",
+        "autunno": "sospesa",
+        "inverno": "sospesa"
+      },
+      "potatura": {
+        "primavera": "nessuna",
+        "estate": "nessuna",
+        "autunno": "nessuna",
+        "inverno": "nessuna"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Aggiunge in `specie.json` il profilo `gasteria` (Gasteria spp.): succulenta a foglie carnose, tollerante alla luce indiretta, con nota sulla colorazione bronzo/porpora come risposta normale a luce forte o freddo (non segno di malattia)
- Aggiunge in `piante.json` la pianta in zona Casa/Soggiorno (vaso di terracotta con ciottoli decorativi), identificata da foto e corretta da Sansevieria a Gasteria su segnalazione dell'utente

## Test plan
- [x] Verificato che entrambi i JSON risultanti siano validi (`jq` parse OK)
- [x] Verificato che non ci siano duplicati con le piante già presenti in Casa/Soggiorno


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4aQMagxU1bcgqwt1fHpp)_