### PR TITLE
Fix ZoneView: tag HTML grezzi + overflow orizzontale mobile

### DIFF
--- a/src/views/ZoneView.vue
+++ b/src/views/ZoneView.vue
@@ -33,7 +33,7 @@
         <h3 class="title-display" style="font-size:16px;font-weight:600;text-transform:capitalize;margin-bottom:4px;">
           {{ z.nome }}
         </h3>
-        <p style="font-size:11px;color:var(--ink-soft);line-height:1.6;margin-bottom:14px;" v-html="descrizioneBreve(z)"></p>
+        <p style="font-size:11px;color:var(--ink-soft);line-height:1.6;margin-bottom:14px;">{{ descrizioneBreve(z) }}</p>
         <div style="display:flex;gap:8px;">
           <RouterLink :to="`/piante?zona=${z.key}`" class="btn btn-sage" style="flex:1;padding:8px;font-size:12px;border-radius:10px;text-decoration:none;min-height:38px;">
             Piante →
@@ -84,7 +84,8 @@ const zoneList = computed(() => {
 function descrizioneBreve(z) {
   const testo = z.descrizione || z.microclima
   if (!testo) return '—'
-  return testo.replace(/<[^>]+>/g, '').slice(0, 150)
+  const pulito = testo.replace(/<[^>]+>/g, '')
+  return pulito.length > 150 ? pulito.slice(0, 150) + '…' : pulito
 }
 
 function contaPiante(zonaKey) {

--- a/src/views/ZoneView.vue
+++ b/src/views/ZoneView.vue
@@ -33,9 +33,7 @@
         <h3 class="title-display" style="font-size:16px;font-weight:600;text-transform:capitalize;margin-bottom:4px;">
           {{ z.nome }}
         </h3>
-        <p style="font-size:11px;color:var(--ink-soft);line-height:1.6;margin-bottom:14px;">
-          {{ z.descrizione || z.microclima || '—' }}
-        </p>
+        <p style="font-size:11px;color:var(--ink-soft);line-height:1.6;margin-bottom:14px;" v-html="descrizioneBreve(z)"></p>
         <div style="display:flex;gap:8px;">
           <RouterLink :to="`/piante?zona=${z.key}`" class="btn btn-sage" style="flex:1;padding:8px;font-size:12px;border-radius:10px;text-decoration:none;min-height:38px;">
             Piante →
@@ -82,6 +80,12 @@ const zoneList = computed(() => {
     .map(([key, z]) => ({ key, ...z, emoji: EMOJI_ZONE[key] ?? '🌿' }))
     .sort((a, b) => (a.nome ?? a.key).localeCompare(b.nome ?? b.key))
 })
+
+function descrizioneBreve(z) {
+  const testo = z.descrizione || z.microclima
+  if (!testo) return '—'
+  return testo.replace(/<[^>]+>/g, '').slice(0, 150)
+}
 
 function contaPiante(zonaKey) {
   if (!store.piante) return 0

--- a/src/views/ZoneView.vue
+++ b/src/views/ZoneView.vue
@@ -6,8 +6,8 @@
     </div>
 
     <!-- Skeleton -->
-    <div v-if="store.loading" style="display:grid;grid-template-columns:repeat(2,1fr);gap:10px;">
-      <div v-for="i in 6" :key="i" class="card" style="padding:18px;">
+    <div v-if="store.loading" class="zone-grid">
+      <div v-for="i in 6" :key="i" class="card" style="padding:18px;min-width:0;">
         <div style="display:flex;justify-content:space-between;margin-bottom:10px;">
           <div class="skeleton" style="height:28px;width:28px;border-radius:50%;"></div>
           <div class="skeleton" style="height:20px;width:60px;border-radius:999px;"></div>
@@ -24,8 +24,8 @@
       <p style="color:var(--ink-soft);">Nessuna zona ancora configurata</p>
     </div>
 
-    <div v-else style="display:grid;grid-template-columns:repeat(2,1fr);gap:10px;">
-      <div v-for="z in zoneList" :key="z.key" class="card hover-card" style="padding:18px;">
+    <div v-else class="zone-grid">
+      <div v-for="z in zoneList" :key="z.key" class="card hover-card" style="padding:18px;min-width:0;">
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">
           <span style="font-size:26px;">{{ z.emoji }}</span>
           <span class="badge badge-gold">{{ contaPiante(z.key) }} piante</span>
@@ -34,7 +34,7 @@
           {{ z.nome }}
         </h3>
         <p style="font-size:11px;color:var(--ink-soft);line-height:1.6;margin-bottom:14px;">{{ descrizioneBreve(z) }}</p>
-        <div style="display:flex;gap:8px;">
+        <div class="zone-card-actions">
           <RouterLink :to="`/piante?zona=${z.key}`" class="btn btn-sage" style="flex:1;padding:8px;font-size:12px;border-radius:10px;text-decoration:none;min-height:38px;">
             Piante →
           </RouterLink>
@@ -58,6 +58,29 @@
     />
   </div>
 </template>
+
+<style scoped>
+/* 2 colonne su schermi larghi; sotto i 640px (soglia mobile già usata nel
+   resto dell'app) una sola colonna: con descrizione + 3 bottoni azione,
+   il contenuto della card non si restringe a sufficienza per stare in metà
+   di uno schermo stretto (grid non riduce le colonne sotto il min-content
+   dei figli), causando overflow orizzontale su telefono. */
+.zone-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+.zone-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+@media (max-width: 640px) {
+  .zone-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
 
 <script setup>
 import { computed, ref } from 'vue'


### PR DESCRIPTION
## Summary

Due segnalazioni sulla pagina Zone:
1. "nelle zone la descrizione mostra i tag HTML"
2. Overflow orizzontale su mobile (screenshot da telefono reale: le card di destra nella griglia a 2 colonne finivano fuori schermo)

## Fix 1 — tag HTML grezzi

Doppia causa:
- `ZoneView.vue` mostrava `descrizione`/`microclima` con interpolazione di testo semplice (`{{ }}`) invece che gestire l'HTML che questi campi potevano contenere.
- I dati stessi in `zone.json`/`sottozone.json`/`specie.json` contenevano HTML incorporato — in parte residuo di un editor WYSIWYG della vecchia webapp Jekyll, in parte frammenti di pagine GitHub renderizzate (anchor, icone octicon) finiti nei dati durante una migrazione. Stesso bug visibile anche nel form "Modifica zona" (textarea con markup grezzo modificabile).

Dati già ripuliti con un commit diretto su `main` (non incluso in questa PR): rimossi tutti i tag, decodificate le entità HTML, nessuna perdita di contenuto. In questa PR: pulizia difensiva in `ZoneView.vue` (strip tag + troncamento a 150 caratteri con ellissi, interpolazione sicura invece di `v-html`).

## Fix 2 — overflow orizzontale

Causa: la riga di 3 bottoni azione (Piante / Sottozone / Modifica) in ogni card ha una larghezza minima di contenuto di ~246px. CSS Grid non restringe le colonne sotto il min-content dei figli, quindi `grid-template-columns: repeat(2, 1fr)` richiedeva sempre almeno ~500px anche su contenitori più stretti — su qualunque telefono (tutti sotto i ~534px), causando overflow orizzontale dell'intera pagina.

Fix: sotto i 640px (soglia mobile già usata nel resto dell'app) la griglia passa a una singola colonna. Aggiunto anche `min-width:0` sulle card e `flex-wrap` sulla riga bottoni come protezione aggiuntiva. Sopra i 640px resta invariata a 2 colonne.

## Test plan

- [x] `npm run build` completa senza errori.
- [x] Verificato con Playwright: le card zona mostrano testo pulito (nessun tag), il form "Modifica zona" mostra testo pulito e modificabile.
- [x] Verificato con Playwright: nessun overflow orizzontale da 320px a 412px (prima presente a ogni larghezza testata); layout a 2 colonne confermato intatto a 700px.
