### PR TITLE
Editor WYSIWYG minimo e modifica sottozone

### DIFF
--- a/src/components/MiniEditor.vue
+++ b/src/components/MiniEditor.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="mini-editor">
+    <div class="mini-editor-toolbar">
+      <button type="button" class="mini-editor-btn" :class="{ attivo: stato.bold }"
+        @mousedown.prevent="formatta('bold')" title="Grassetto"><b>B</b></button>
+      <button type="button" class="mini-editor-btn" :class="{ attivo: stato.italic }"
+        @mousedown.prevent="formatta('italic')" title="Corsivo"><i>I</i></button>
+    </div>
+    <div
+      ref="editabileEl"
+      class="mini-editor-content form-input"
+      contenteditable="true"
+      :data-placeholder="placeholder"
+      @input="onInput"
+      @keyup="aggiornaStato"
+      @mouseup="aggiornaStato"
+      @focus="aggiornaStato"
+      @blur="onInput"
+    ></div>
+  </div>
+</template>
+
+<script setup>
+// Editor WYSIWYG minimo: solo paragrafi, grassetto e corsivo. Pensato per
+// sostituire le textarea su descrizione/microclima di zone e sottozone,
+// che in passato finivano per contenere HTML incollato a mano (o peggio,
+// markup scaricato da pagine GitHub renderizzate — vedi pulizia dati in
+// "Rimuove l'HTML incorporato da zone/sottozone/specie"). L'output è
+// sempre passato da sanitizza(), che ammette solo p/br/b/strong/i/em senza
+// alcun attributo: nessun tag/attributo arbitrario può finire nei dati,
+// quindi è sicuro visualizzarlo in futuro con v-html.
+import { ref, onMounted, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  placeholder: { type: String, default: '' },
+})
+const emit = defineEmits(['update:modelValue'])
+
+const editabileEl = ref(null)
+const stato = ref({ bold: false, italic: false })
+
+const TAG_CONSENTITI = new Set(['P', 'BR', 'B', 'STRONG', 'I', 'EM'])
+
+function sanitizza(html) {
+  const contenitore = document.createElement('div')
+  contenitore.innerHTML = html
+
+  function pulisciNodo(nodo) {
+    ;[...nodo.childNodes].forEach(figlio => {
+      if (figlio.nodeType !== 1) return // testo/commenti: lasciati stare
+
+      // I browser contenteditable spesso usano <div> per i paragrafi: li
+      // trattiamo come equivalenti a <p>.
+      const tag = figlio.tagName === 'DIV' ? 'P' : figlio.tagName
+
+      if (!TAG_CONSENTITI.has(tag)) {
+        // Tag non ammesso: ne conserviamo solo il contenuto testuale/inline
+        while (figlio.firstChild) nodo.insertBefore(figlio.firstChild, figlio)
+        nodo.removeChild(figlio)
+        return
+      }
+
+      if (figlio.tagName === 'DIV') {
+        const p = document.createElement('p')
+        p.innerHTML = figlio.innerHTML
+        nodo.replaceChild(p, figlio)
+        pulisciNodo(p)
+        return
+      }
+
+      // Rimuove tutti gli attributi (style, class, ecc.)
+      ;[...figlio.attributes].forEach(attr => figlio.removeAttribute(attr.name))
+      pulisciNodo(figlio)
+    })
+  }
+
+  pulisciNodo(contenitore)
+  return contenitore.innerHTML
+}
+
+function onInput() {
+  emit('update:modelValue', sanitizza(editabileEl.value.innerHTML))
+}
+
+function formatta(comando) {
+  document.execCommand(comando, false, null)
+  editabileEl.value.focus()
+  aggiornaStato()
+  onInput()
+}
+
+function aggiornaStato() {
+  stato.value.bold = document.queryCommandState('bold')
+  stato.value.italic = document.queryCommandState('italic')
+}
+
+onMounted(() => {
+  try { document.execCommand('defaultParagraphSeparator', false, 'p') } catch { /* browser più vecchi: ignorato */ }
+  editabileEl.value.innerHTML = props.modelValue || ''
+})
+
+// Riallinea il contenuto se il valore esterno cambia per motivi non legati
+// alla digitazione (es. reset del form, caricamento di un altro record).
+watch(() => props.modelValue, (nuovo) => {
+  if (editabileEl.value && nuovo !== editabileEl.value.innerHTML) {
+    editabileEl.value.innerHTML = nuovo || ''
+  }
+})
+</script>
+
+<style scoped>
+.mini-editor-toolbar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.mini-editor-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--cream-dark, #ddd);
+  background: var(--white, #fff);
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mini-editor-btn.attivo {
+  background: var(--sage-pale, #e4ede4);
+  border-color: var(--sage, #7a9e82);
+}
+.mini-editor-content {
+  min-height: 90px;
+  overflow-y: auto;
+  line-height: 1.5;
+}
+.mini-editor-content :deep(p) {
+  margin: 0 0 8px 0;
+}
+.mini-editor-content :deep(p:last-child) {
+  margin-bottom: 0;
+}
+.mini-editor-content:empty::before {
+  content: attr(data-placeholder);
+  color: var(--ink-faint, #999);
+}
+</style>

--- a/src/components/MiniEditor.vue
+++ b/src/components/MiniEditor.vue
@@ -50,6 +50,13 @@ function sanitizza(html) {
     ;[...nodo.childNodes].forEach(figlio => {
       if (figlio.nodeType !== 1) return // testo/commenti: lasciati stare
 
+      // Pulisce prima i figli (bottom-up): se ripulissimo il nodo corrente
+      // prima di ricorrere, un tag non ammesso rimosso qui (es. <span>)
+      // potrebbe "risalire" figli pericolosi (es. <script>) nel genitore
+      // senza che vengano più visitati, dato che l'iterazione avviene su
+      // uno snapshot statico dei childNodes preso a inizio forEach.
+      pulisciNodo(figlio)
+
       // I browser contenteditable spesso usano <div> per i paragrafi: li
       // trattiamo come equivalenti a <p>.
       const tag = figlio.tagName === 'DIV' ? 'P' : figlio.tagName
@@ -63,15 +70,13 @@ function sanitizza(html) {
 
       if (figlio.tagName === 'DIV') {
         const p = document.createElement('p')
-        p.innerHTML = figlio.innerHTML
+        while (figlio.firstChild) p.appendChild(figlio.firstChild)
         nodo.replaceChild(p, figlio)
-        pulisciNodo(p)
         return
       }
 
       // Rimuove tutti gli attributi (style, class, ecc.)
       ;[...figlio.attributes].forEach(attr => figlio.removeAttribute(attr.name))
-      pulisciNodo(figlio)
     })
   }
 
@@ -103,7 +108,12 @@ onMounted(() => {
 // Riallinea il contenuto se il valore esterno cambia per motivi non legati
 // alla digitazione (es. reset del form, caricamento di un altro record).
 watch(() => props.modelValue, (nuovo) => {
-  if (editabileEl.value && nuovo !== editabileEl.value.innerHTML) {
+  // Confronta con la versione sanitizzata dell'HTML corrente, non con
+  // l'innerHTML grezzo del browser: quest'ultimo può differire leggermente
+  // (spazi, formattazione tag) dal valore sanitizzato anche quando il
+  // contenuto logico non è cambiato, causando altrimenti un riassegnamento
+  // di innerHTML ad ogni digitazione e il salto del cursore all'inizio.
+  if (editabileEl.value && nuovo !== sanitizza(editabileEl.value.innerHTML)) {
     editabileEl.value.innerHTML = nuovo || ''
   }
 })

--- a/src/views/EditZonaView.vue
+++ b/src/views/EditZonaView.vue
@@ -22,12 +22,10 @@
 
       <div class="card" style="padding:16px;">
         <label style="font-size:11px;font-weight:600;color:var(--ink-soft);text-transform:uppercase;letter-spacing:.05em;display:block;margin-bottom:6px;">Descrizione</label>
-        <textarea v-model="form.descrizione" placeholder="Descrizione breve della zona…"
-          rows="3" class="form-input" style="resize:vertical;font-family:inherit;margin-bottom:12px;"></textarea>
+        <MiniEditor v-model="form.descrizione" placeholder="Descrizione breve della zona…" />
 
-        <label style="font-size:11px;font-weight:600;color:var(--ink-soft);text-transform:uppercase;letter-spacing:.05em;display:block;margin-bottom:6px;">Microclima</label>
-        <textarea v-model="form.microclima" placeholder="Caratteristiche di luce, temperatura, umidità…"
-          rows="3" class="form-input" style="resize:vertical;font-family:inherit;"></textarea>
+        <label style="font-size:11px;font-weight:600;color:var(--ink-soft);text-transform:uppercase;letter-spacing:.05em;display:block;margin:12px 0 6px;">Microclima</label>
+        <MiniEditor v-model="form.microclima" placeholder="Caratteristiche di luce, temperatura, umidità…" />
       </div>
 
       <div class="card" style="padding:16px;">
@@ -54,6 +52,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useDatiStore } from '@/stores/dati'
 import { useApi } from '@/composables/useApi'
+import MiniEditor from '@/components/MiniEditor.vue'
 
 const route  = useRoute()
 const router = useRouter()

--- a/src/views/SottozoneView.vue
+++ b/src/views/SottozoneView.vue
@@ -11,7 +11,7 @@
         </h1>
         <p style="font-size:13px;color:var(--ink-soft);margin-top:2px;">Sottozone</p>
       </div>
-      <button @click="mostraForm = true" class="btn btn-rose" style="padding:8px 14px;">＋ Aggiungi</button>
+      <button @click="apriNuovo" class="btn btn-rose" style="padding:8px 14px;">＋ Aggiungi</button>
     </div>
 
     <div v-if="!sottozone.length" style="text-align:center;padding:60px 20px;color:var(--ink-faint);">
@@ -23,33 +23,36 @@
       <div v-for="sz in sottozone" :key="sz.nome" class="card" style="padding:16px;">
         <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:8px;">
           <h3 class="title-serif" style="font-size:15px;font-weight:600;">{{ sz.nome }}</h3>
-          <div style="display:flex;gap:6px;">
+          <div style="display:flex;gap:6px;align-items:center;">
             <span v-if="sz.tipo" class="badge" :style="sz.tipo === 'interno' ? 'background:var(--sage-pale);color:var(--sage-dark);' : 'background:var(--gold-pale);color:var(--gold-dark);'">
               {{ sz.tipo }}
             </span>
+            <button type="button" class="btn btn-ghost" style="padding:6px 8px;font-size:13px;border-radius:8px;"
+              @click="apriModifica(sz)" title="Modifica sottozona">✏️</button>
           </div>
         </div>
         <div v-if="sz.esposizione?.length" style="font-size:11px;color:var(--ink-faint);margin-bottom:6px;">
           ☀️ {{ sz.esposizione.join(', ') }}
         </div>
-        <div v-if="sz.descrizione" style="font-size:12px;color:var(--ink-soft);line-height:1.5;" v-html="sz.descrizione?.replace(/<[^>]+>/g,'').slice(0,150)"></div>
+        <p v-if="sz.descrizione" style="font-size:12px;color:var(--ink-soft);line-height:1.5;">{{ descrizioneBreve(sz) }}</p>
       </div>
     </div>
 
-    <!-- Form nuova sottozona -->
+    <!-- Form nuova/modifica sottozona -->
     <Teleport to="body">
-      <div v-if="mostraForm" class="overlay" @click.self="mostraForm = false">
+      <div v-if="mostraForm" class="overlay" @click.self="chiudiForm">
         <div class="modal-box">
-          <h3 style="font-family:var(--font-serif);font-size:16px;font-weight:600;margin-bottom:16px;">Nuova sottozona</h3>
+          <h3 style="font-family:var(--font-serif);font-size:16px;font-weight:600;margin-bottom:16px;">
+            {{ modificaOriginale ? 'Modifica sottozona' : 'Nuova sottozona' }}
+          </h3>
           <input v-model="form.nome" placeholder="Nome *" class="form-input" style="margin-bottom:10px;">
-          <textarea v-model="form.descrizione" placeholder="Descrizione (opzionale)" rows="3"
-            class="form-input" style="resize:vertical;font-family:inherit;margin-bottom:10px;"></textarea>
-          <select v-model="form.tipo" class="form-input" style="margin-bottom:16px;">
+          <MiniEditor v-model="form.descrizione" placeholder="Descrizione (opzionale)" />
+          <select v-model="form.tipo" class="form-input" style="margin:10px 0 16px;">
             <option value="esterno">Esterno</option>
             <option value="interno">Interno</option>
           </select>
           <div style="display:flex;gap:10px;justify-content:flex-end;">
-            <button class="btn btn-ghost" @click="mostraForm = false" style="min-height:40px;padding:8px 16px;">Annulla</button>
+            <button class="btn btn-ghost" @click="chiudiForm" style="min-height:40px;padding:8px 16px;">Annulla</button>
             <button class="btn btn-sage" @click="salva" :disabled="!form.nome.trim() || salvando"
               style="min-height:40px;padding:8px 16px;">
               {{ salvando ? '⏳' : 'Salva' }}
@@ -66,6 +69,7 @@ import { ref, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useDatiStore } from '@/stores/dati'
 import { useApi } from '@/composables/useApi'
+import MiniEditor from '@/components/MiniEditor.vue'
 
 const route = useRoute()
 const store = useDatiStore()
@@ -74,6 +78,10 @@ const { saveJSON } = useApi()
 const mostraForm = ref(false)
 const salvando   = ref(false)
 const form = ref({ nome: '', descrizione: '', tipo: 'esterno' })
+// Nome originale della sottozona in modifica (null quando si sta creando una
+// nuova sottozona): serve per sapere quale chiave aggiornare/rinominare in
+// sottozone.json, dato che è indicizzato per nome.
+const modificaOriginale = ref(null)
 
 const zona = computed(() => store.zone?.[route.params.zona] ?? null)
 const sottozone = computed(() => {
@@ -82,29 +90,80 @@ const sottozone = computed(() => {
   return Object.values(sz)
 })
 
+function descrizioneBreve(sz) {
+  const pulito = (sz.descrizione || '').replace(/<[^>]+>/g, '')
+  return pulito.length > 150 ? pulito.slice(0, 150) + '…' : pulito
+}
+
+function apriNuovo() {
+  modificaOriginale.value = null
+  form.value = { nome: '', descrizione: '', tipo: 'esterno' }
+  mostraForm.value = true
+}
+
+function apriModifica(sz) {
+  modificaOriginale.value = sz.nome
+  form.value = { nome: sz.nome, descrizione: sz.descrizione || '', tipo: sz.tipo || 'esterno' }
+  mostraForm.value = true
+}
+
+function chiudiForm() {
+  mostraForm.value = false
+  modificaOriginale.value = null
+  form.value = { nome: '', descrizione: '', tipo: 'esterno' }
+}
+
 async function salva() {
   if (!form.value.nome.trim() || salvando.value) return
   salvando.value = true
+  const nomeOriginale = modificaOriginale.value
+  const nomeNuovo = form.value.nome.trim()
   try {
     const nuove = await saveJSON('sottozone.json', (correnti) => {
       const base = { ...(correnti ?? store.sottozone) }
-      base[route.params.zona] = {
-        ...(base[route.params.zona] ?? {}),
-        [form.value.nome]: {
-          nome:        form.value.nome.trim(),
-          descrizione: form.value.descrizione.trim() || '',
-          tipo:        form.value.tipo,
-          esposizione: [],
-          microclima:  '',
-          criticita:   '',
-          manutenzione:'',
-        }
+      const sottozoneZona = { ...(base[route.params.zona] ?? {}) }
+
+      // In modifica, riparte dal record esistente (per non perdere
+      // esposizione/microclima/criticita/manutenzione, non gestiti da questo
+      // form) e lo rimuove dalla vecchia chiave se il nome è cambiato.
+      const esistente = nomeOriginale ? (sottozoneZona[nomeOriginale] ?? {}) : {}
+      if (nomeOriginale && nomeOriginale !== nomeNuovo) {
+        delete sottozoneZona[nomeOriginale]
       }
+
+      sottozoneZona[nomeNuovo] = {
+        ...esistente,
+        nome:        nomeNuovo,
+        descrizione: form.value.descrizione.trim() || '',
+        tipo:        form.value.tipo,
+        esposizione: esistente.esposizione ?? [],
+        microclima:  esistente.microclima  ?? '',
+        criticita:   esistente.criticita   ?? '',
+        manutenzione:esistente.manutenzione ?? '',
+      }
+
+      base[route.params.zona] = sottozoneZona
       return base
     })
     store.sottozone = nuove
-    mostraForm.value = false
-    form.value = { nome: '', descrizione: '', tipo: 'esterno' }
+
+    // Se il nome è cambiato, aggiorna anche le piante che referenziano la
+    // vecchia sottozona: altrimenti resterebbero "orfane" (sottozona
+    // inesistente) invece di seguire la rinomina.
+    if (nomeOriginale && nomeOriginale !== nomeNuovo) {
+      const nuovePiante = await saveJSON('piante.json', (correnti) => {
+        const base = { ...(correnti ?? store.piante) }
+        for (const id of Object.keys(base)) {
+          if (base[id].zona === route.params.zona && base[id].sottozona === nomeOriginale) {
+            base[id] = { ...base[id], sottozona: nomeNuovo }
+          }
+        }
+        return base
+      })
+      store.piante = nuovePiante
+    }
+
+    chiudiForm()
   } finally {
     salvando.value = false
   }

--- a/src/views/SottozoneView.vue
+++ b/src/views/SottozoneView.vue
@@ -47,6 +47,7 @@
           </h3>
           <input v-model="form.nome" placeholder="Nome *" class="form-input" style="margin-bottom:10px;">
           <MiniEditor v-model="form.descrizione" placeholder="Descrizione (opzionale)" />
+          <p v-if="errore" style="font-size:11px;color:var(--rose-dark);margin:6px 0 0;">{{ errore }}</p>
           <select v-model="form.tipo" class="form-input" style="margin:10px 0 16px;">
             <option value="esterno">Esterno</option>
             <option value="interno">Interno</option>
@@ -77,6 +78,7 @@ const { saveJSON } = useApi()
 
 const mostraForm = ref(false)
 const salvando   = ref(false)
+const errore     = ref(null)
 const form = ref({ nome: '', descrizione: '', tipo: 'esterno' })
 // Nome originale della sottozona in modifica (null quando si sta creando una
 // nuova sottozona): serve per sapere quale chiave aggiornare/rinominare in
@@ -98,12 +100,14 @@ function descrizioneBreve(sz) {
 function apriNuovo() {
   modificaOriginale.value = null
   form.value = { nome: '', descrizione: '', tipo: 'esterno' }
+  errore.value = null
   mostraForm.value = true
 }
 
 function apriModifica(sz) {
   modificaOriginale.value = sz.nome
   form.value = { nome: sz.nome, descrizione: sz.descrizione || '', tipo: sz.tipo || 'esterno' }
+  errore.value = null
   mostraForm.value = true
 }
 
@@ -111,13 +115,25 @@ function chiudiForm() {
   mostraForm.value = false
   modificaOriginale.value = null
   form.value = { nome: '', descrizione: '', tipo: 'esterno' }
+  errore.value = null
 }
 
 async function salva() {
   if (!form.value.nome.trim() || salvando.value) return
-  salvando.value = true
   const nomeOriginale = modificaOriginale.value
   const nomeNuovo = form.value.nome.trim()
+
+  // Evita di sovrascrivere silenziosamente un'altra sottozona già esistente
+  // con lo stesso nome (perderebbe esposizione/microclima/criticita/
+  // manutenzione non gestiti da questo form).
+  const sottozoneDellaZona = store.sottozone?.[route.params.zona] ?? {}
+  if (sottozoneDellaZona[nomeNuovo] && nomeNuovo !== nomeOriginale) {
+    errore.value = 'Una sottozona con questo nome esiste già in questa zona.'
+    return
+  }
+  errore.value = null
+
+  salvando.value = true
   try {
     const nuove = await saveJSON('sottozone.json', (correnti) => {
       const base = { ...(correnti ?? store.sottozone) }


### PR DESCRIPTION
## Summary
- Le sottozone erano creabili ed eliminabili ma non modificabili: aggiunge un pulsante ✏️ su ogni card di `SottozoneView.vue` che apre il form precompilato, con `salva()` riscritta per gestire sia creazione sia modifica (rinomina inclusa)
- Quando una sottozona viene rinominata, la modifica viene propagata a cascata alle piante collegate in `piante.json` (altrimenti resterebbero orfane, riferendo una sottozona inesistente)
- Aggiunge `src/components/MiniEditor.vue`: editor WYSIWYG minimo (solo paragrafi, grassetto, corsivo) basato su `contenteditable`, con un sanitizzatore ad allowlist rigida (`p/br/b/strong/i/em`, nessun attributo) per garantire che l'HTML salvato non contenga mai markup arbitrario
- Sostituisce le textarea semplici di descrizione/microclima con `MiniEditor` in `EditZonaView.vue` e nel form sottozone di `SottozoneView.vue`

## Test plan
- [x] Build di produzione (`npm run build`) senza errori
- [x] Test Playwright end-to-end (Contents API mockata) che verifica: creazione nuova sottozona con testo in grassetto tramite la toolbar del MiniEditor, corretto salvataggio HTML sanitizzato in `sottozone.json`; apertura form di modifica su una sottozona esistente con prefill corretto di nome/descrizione; rinomina che aggiorna sia le chiavi in `sottozone.json` sia il campo `sottozona` della pianta collegata in `piante.json`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_