### PR TITLE
Fix layout badge/icona sottozone e campo esposizione mancante

### DIFF
--- a/src/views/SottozoneView.vue
+++ b/src/views/SottozoneView.vue
@@ -113,7 +113,7 @@ function apriNuovo() {
 
 function apriModifica(sz) {
   modificaOriginale.value = sz.nome
-  form.value = { nome: sz.nome, descrizione: sz.descrizione || '', tipo: sz.tipo || 'esterno', esposizione: sz.esposizione ?? [] }
+  form.value = { nome: sz.nome, descrizione: sz.descrizione || '', tipo: sz.tipo || 'esterno', esposizione: sz.esposizione ? [...sz.esposizione] : [] }
   errore.value = null
   mostraForm.value = true
 }

--- a/src/views/SottozoneView.vue
+++ b/src/views/SottozoneView.vue
@@ -23,12 +23,11 @@
       <div v-for="sz in sottozone" :key="sz.nome" class="card" style="padding:16px;">
         <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:8px;">
           <h3 class="title-serif" style="font-size:15px;font-weight:600;">{{ sz.nome }}</h3>
-          <div style="display:flex;gap:6px;align-items:center;">
+          <div style="display:flex;gap:8px;align-items:center;">
             <span v-if="sz.tipo" class="badge" :style="sz.tipo === 'interno' ? 'background:var(--sage-pale);color:var(--sage-dark);' : 'background:var(--gold-pale);color:var(--gold-dark);'">
               {{ sz.tipo }}
             </span>
-            <button type="button" class="btn btn-ghost" style="padding:6px 8px;font-size:13px;border-radius:8px;"
-              @click="apriModifica(sz)" title="Modifica sottozona">✏️</button>
+            <button type="button" class="icon-btn" @click="apriModifica(sz)" title="Modifica sottozona">✏️</button>
           </div>
         </div>
         <div v-if="sz.esposizione?.length" style="font-size:11px;color:var(--ink-faint);margin-bottom:6px;">
@@ -48,10 +47,18 @@
           <input v-model="form.nome" placeholder="Nome *" class="form-input" style="margin-bottom:10px;">
           <MiniEditor v-model="form.descrizione" placeholder="Descrizione (opzionale)" />
           <p v-if="errore" style="font-size:11px;color:var(--rose-dark);margin:6px 0 0;">{{ errore }}</p>
-          <select v-model="form.tipo" class="form-input" style="margin:10px 0 16px;">
+          <select v-model="form.tipo" class="form-input" style="margin:10px 0;">
             <option value="esterno">Esterno</option>
             <option value="interno">Interno</option>
           </select>
+          <label style="font-size:11px;font-weight:600;color:var(--ink-soft);text-transform:uppercase;letter-spacing:.05em;display:block;margin-bottom:6px;">Esposizione</label>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;">
+            <label v-for="dir in ['nord','sud','est','ovest']" :key="dir"
+              style="display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;">
+              <input type="checkbox" :value="dir" v-model="form.esposizione" style="accent-color:var(--sage);">
+              {{ dir }}
+            </label>
+          </div>
           <div style="display:flex;gap:10px;justify-content:flex-end;">
             <button class="btn btn-ghost" @click="chiudiForm" style="min-height:40px;padding:8px 16px;">Annulla</button>
             <button class="btn btn-sage" @click="salva" :disabled="!form.nome.trim() || salvando"
@@ -79,7 +86,7 @@ const { saveJSON } = useApi()
 const mostraForm = ref(false)
 const salvando   = ref(false)
 const errore     = ref(null)
-const form = ref({ nome: '', descrizione: '', tipo: 'esterno' })
+const form = ref({ nome: '', descrizione: '', tipo: 'esterno', esposizione: [] })
 // Nome originale della sottozona in modifica (null quando si sta creando una
 // nuova sottozona): serve per sapere quale chiave aggiornare/rinominare in
 // sottozone.json, dato che è indicizzato per nome.
@@ -99,14 +106,14 @@ function descrizioneBreve(sz) {
 
 function apriNuovo() {
   modificaOriginale.value = null
-  form.value = { nome: '', descrizione: '', tipo: 'esterno' }
+  form.value = { nome: '', descrizione: '', tipo: 'esterno', esposizione: [] }
   errore.value = null
   mostraForm.value = true
 }
 
 function apriModifica(sz) {
   modificaOriginale.value = sz.nome
-  form.value = { nome: sz.nome, descrizione: sz.descrizione || '', tipo: sz.tipo || 'esterno' }
+  form.value = { nome: sz.nome, descrizione: sz.descrizione || '', tipo: sz.tipo || 'esterno', esposizione: sz.esposizione ?? [] }
   errore.value = null
   mostraForm.value = true
 }
@@ -114,7 +121,7 @@ function apriModifica(sz) {
 function chiudiForm() {
   mostraForm.value = false
   modificaOriginale.value = null
-  form.value = { nome: '', descrizione: '', tipo: 'esterno' }
+  form.value = { nome: '', descrizione: '', tipo: 'esterno', esposizione: [] }
   errore.value = null
 }
 
@@ -152,7 +159,7 @@ async function salva() {
         nome:        nomeNuovo,
         descrizione: form.value.descrizione.trim() || '',
         tipo:        form.value.tipo,
-        esposizione: esistente.esposizione ?? [],
+        esposizione: form.value.esposizione,
         microclima:  esistente.microclima  ?? '',
         criticita:   esistente.criticita   ?? '',
         manutenzione:esistente.manutenzione ?? '',
@@ -187,6 +194,18 @@ async function salva() {
 </script>
 
 <style scoped>
+/* Pulsante icona "trasparente": accanto al badge tipo (interno/esterno) uno
+   stile .btn-ghost pieno (sfondo tan) creava due "pillole" scure ravvicinate
+   che si affollavano visivamente; qui lo sfondo compare solo in hover. */
+.icon-btn {
+  background: none; border: none; cursor: pointer;
+  padding: 4px 6px; border-radius: 8px; font-size: 14px; line-height: 1;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ink-soft);
+}
+.icon-btn:hover {
+  background: var(--cream-dark);
+}
 .overlay {
   position: fixed; inset: 0; z-index: 200;
   background: rgba(42,34,24,0.4);


### PR DESCRIPTION
## Summary
Follow-up alla PR #22, in base a un riscontro sull'app reale:
- Il pulsante di modifica (✏️) su ogni card sottozona usava `.btn-ghost` (sfondo pieno tan), che affiancato al badge colorato tipo (interno/esterno) creava due "pillole" ravvicinate poco leggibili, soprattutto su schermi stretti. Ora è un'icona trasparente, con sfondo solo in hover.
- Il form di creazione/modifica sottozona non esponeva il campo `esposizione` (nord/sud/est/ovest): per le sottozone esistenti veniva preservato solo tramite spread del record originale (non editabile), e per le nuove sottozone restava sempre vuoto. Aggiunti gli stessi checkbox già usati in `EditZonaView.vue`.

## Test plan
- [x] Build di produzione (`npm run build`) senza errori
- [x] Verifica visiva con Playwright: badge e icona modifica non più affollati
- [x] Test Playwright: apertura form di modifica su una sottozona reale, verifica che i checkbox esposizione siano precompilati correttamente in base ai dati esistenti, modifica e salvataggio corretto del nuovo array esposizione


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_