### PR TITLE
Combobox ricercabile per la specie + creazione al volo

### DIFF
--- a/src/views/EditPiantaView.vue
+++ b/src/views/EditPiantaView.vue
@@ -141,10 +141,15 @@ function selezionaSpecie(s) {
 }
 
 function chiudiDropdown() {
-  dropdownAperto.value = false
-  // Se l'utente ha digitato senza selezionare nulla dall'elenco, ripristina
-  // il testo sul nome della specie effettivamente selezionata (o vuoto).
-  specieQuery.value = store.specie?.[form.value.specie]?.nome ?? ''
+  // Ritardo breve: su alcuni browser mobile il blur dell'input scatta prima
+  // che il tap sull'opzione (gestito da @mousedown.prevent) venga elaborato,
+  // altrimenti il dropdown sparirebbe dal DOM prima della selezione.
+  setTimeout(() => {
+    dropdownAperto.value = false
+    // Se l'utente ha digitato senza selezionare nulla dall'elenco, ripristina
+    // il testo sul nome della specie effettivamente selezionata (o vuoto).
+    specieQuery.value = store.specie?.[form.value.specie]?.nome ?? ''
+  }, 150)
 }
 
 const mostraNuovaSpecie = ref(false)
@@ -176,6 +181,10 @@ async function salvaNuovaSpecie() {
   const nome = nuovaSpecie.value.nome.trim()
   if (!nome || salvandoSpecie.value) return
   const chiave = slug(nome)
+  if (!chiave) {
+    erroreSpecie.value = 'Il nome della specie deve contenere almeno una lettera o un numero.'
+    return
+  }
   if (store.specie?.[chiave]) {
     erroreSpecie.value = 'Una specie con questo nome esiste già.'
     return
@@ -203,6 +212,8 @@ async function salvaNuovaSpecie() {
     store.specie = nuove
     selezionaSpecie({ key: chiave, nome })
     mostraNuovaSpecie.value = false
+  } catch (e) {
+    erroreSpecie.value = e.message || 'Errore durante il salvataggio della specie.'
   } finally {
     salvandoSpecie.value = false
   }

--- a/src/views/EditPiantaView.vue
+++ b/src/views/EditPiantaView.vue
@@ -11,12 +11,26 @@
 
     <div style="display:flex;flex-direction:column;gap:10px;">
       <!-- Specie -->
-      <div class="card" style="padding:16px;">
+      <div class="card" style="padding:16px;position:relative;">
         <label style="font-size:11px;font-weight:600;color:var(--ink-soft);text-transform:uppercase;letter-spacing:.05em;display:block;margin-bottom:6px;">Specie *</label>
-        <select v-model="form.specie" class="form-input">
-          <option value="">Seleziona specie…</option>
-          <option v-for="(s, key) in store.specie ?? {}" :key="key" :value="key">{{ s.nome }}</option>
-        </select>
+        <input
+          v-model="specieQuery"
+          @focus="dropdownAperto = true"
+          @click="dropdownAperto = true"
+          @blur="chiudiDropdown"
+          placeholder="Cerca specie…"
+          class="form-input"
+          autocomplete="off"
+        >
+        <div v-if="dropdownAperto" class="specie-dropdown">
+          <div v-for="s in specieFiltrate" :key="s.key" class="specie-opzione" @mousedown.prevent="selezionaSpecie(s)">
+            {{ s.nome }}
+          </div>
+          <p v-if="!specieFiltrate.length" style="font-size:12px;color:var(--ink-faint);padding:8px 10px;">Nessuna specie trovata</p>
+          <div class="specie-opzione specie-nuova" @mousedown.prevent="apriNuovaSpecie">
+            ＋ Aggiungi nuova specie{{ specieQuery.trim() ? ` "${specieQuery.trim()}"` : '' }}
+          </div>
+        </div>
       </div>
 
       <!-- Zona -->
@@ -56,6 +70,34 @@
         {{ salvando ? '⏳ Salvataggio…' : (isNuova ? 'Aggiungi pianta' : 'Salva modifiche') }}
       </button>
     </div>
+
+    <!-- Modale nuova specie -->
+    <Teleport to="body">
+      <div v-if="mostraNuovaSpecie" class="overlay" @click.self="chiudiNuovaSpecie">
+        <div class="modal-box">
+          <h3 style="font-family:var(--font-serif);font-size:16px;font-weight:600;margin-bottom:16px;">Nuova specie</h3>
+
+          <input v-model="nuovaSpecie.nome" placeholder="Nome *" class="form-input" style="margin-bottom:10px;">
+          <p v-if="erroreSpecie" style="font-size:11px;color:var(--rose-dark);margin:0 0 10px;">{{ erroreSpecie }}</p>
+
+          <textarea v-model="nuovaSpecie.descrizione" placeholder="Descrizione (opzionale)"
+            rows="2" class="form-input" style="resize:vertical;font-family:inherit;margin-bottom:10px;"></textarea>
+
+          <label style="font-size:11px;font-weight:600;color:var(--ink-soft);text-transform:uppercase;letter-spacing:.05em;display:block;margin-bottom:6px;">Esigenze (opzionale)</label>
+          <input v-model="nuovaSpecie.luce" placeholder="Luce, es. Pieno sole" class="form-input" style="margin-bottom:8px;">
+          <input v-model="nuovaSpecie.acqua" placeholder="Acqua, es. Moderata" class="form-input" style="margin-bottom:8px;">
+          <input v-model="nuovaSpecie.terreno" placeholder="Terreno, es. Ben drenato" class="form-input" style="margin-bottom:16px;">
+
+          <div style="display:flex;gap:10px;justify-content:flex-end;">
+            <button class="btn btn-ghost" @click="chiudiNuovaSpecie" style="min-height:40px;padding:8px 16px;">Annulla</button>
+            <button class="btn btn-sage" @click="salvaNuovaSpecie" :disabled="!nuovaSpecie.nome.trim() || salvandoSpecie"
+              style="min-height:40px;padding:8px 16px;">
+              {{ salvandoSpecie ? '⏳' : 'Aggiungi' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -76,6 +118,95 @@ const salvando = ref(false)
 const form = ref({
   specie: '', zona: '', sottozona: '', varieta: '', impianto: '', note: ''
 })
+
+// Combobox specie: testo digitato per filtrare l'elenco (~80+ specie, troppe
+// per una <select> nativa comoda su mobile) più un'opzione per crearne una
+// nuova al volo senza uscire dal form pianta.
+const specieQuery    = ref('')
+const dropdownAperto = ref(false)
+
+const specieFiltrate = computed(() => {
+  const tutte = Object.entries(store.specie ?? {})
+    .map(([key, s]) => ({ key, nome: s.nome ?? key }))
+    .sort((a, b) => a.nome.localeCompare(b.nome))
+  const q = specieQuery.value.trim().toLowerCase()
+  if (!q) return tutte
+  return tutte.filter(s => s.nome.toLowerCase().includes(q))
+})
+
+function selezionaSpecie(s) {
+  form.value.specie = s.key
+  specieQuery.value = s.nome
+  dropdownAperto.value = false
+}
+
+function chiudiDropdown() {
+  dropdownAperto.value = false
+  // Se l'utente ha digitato senza selezionare nulla dall'elenco, ripristina
+  // il testo sul nome della specie effettivamente selezionata (o vuoto).
+  specieQuery.value = store.specie?.[form.value.specie]?.nome ?? ''
+}
+
+const mostraNuovaSpecie = ref(false)
+const salvandoSpecie    = ref(false)
+const erroreSpecie      = ref(null)
+const nuovaSpecie = ref({ nome: '', descrizione: '', luce: '', acqua: '', terreno: '' })
+
+function slug(testo) {
+  return testo
+    .toLowerCase()
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function apriNuovaSpecie() {
+  nuovaSpecie.value = { nome: specieQuery.value.trim(), descrizione: '', luce: '', acqua: '', terreno: '' }
+  erroreSpecie.value = null
+  dropdownAperto.value = false
+  mostraNuovaSpecie.value = true
+}
+
+function chiudiNuovaSpecie() {
+  mostraNuovaSpecie.value = false
+  erroreSpecie.value = null
+}
+
+async function salvaNuovaSpecie() {
+  const nome = nuovaSpecie.value.nome.trim()
+  if (!nome || salvandoSpecie.value) return
+  const chiave = slug(nome)
+  if (store.specie?.[chiave]) {
+    erroreSpecie.value = 'Una specie con questo nome esiste già.'
+    return
+  }
+  erroreSpecie.value = null
+
+  salvandoSpecie.value = true
+  try {
+    const nuove = await saveJSON('specie.json', (correnti) => {
+      const base = { ...(correnti ?? store.specie) }
+      base[chiave] = {
+        nome,
+        specie: nome,
+        descrizione: nuovaSpecie.value.descrizione.trim() || '',
+        esigenze: {
+          luce:    nuovaSpecie.value.luce.trim()    || '',
+          acqua:   nuovaSpecie.value.acqua.trim()   || '',
+          terreno: nuovaSpecie.value.terreno.trim() || '',
+        },
+        alert: [],
+        manutenzione: { irrigazione: {}, concimazione: {}, potatura: {} },
+      }
+      return base
+    })
+    store.specie = nuove
+    selezionaSpecie({ key: chiave, nome })
+    mostraNuovaSpecie.value = false
+  } finally {
+    salvandoSpecie.value = false
+  }
+}
 
 const sottozoneZona = computed(() => {
   if (!form.value.zona || !store.sottozone) return []
@@ -98,6 +229,7 @@ onMounted(async () => {
       impianto:  p.impianto  ?? '',
       note:      p.note      ?? '',
     }
+    specieQuery.value = store.specie?.[form.value.specie]?.nome ?? ''
   }
 })
 
@@ -128,3 +260,41 @@ async function salva() {
   }
 }
 </script>
+
+<style scoped>
+.specie-dropdown {
+  position: absolute;
+  left: 16px; right: 16px;
+  margin-top: 4px;
+  background: var(--white);
+  border: 1px solid var(--cream-dark);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(42,34,24,0.15);
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 50;
+}
+.specie-opzione {
+  padding: 10px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.specie-opzione:hover {
+  background: var(--cream);
+}
+.specie-nuova {
+  color: var(--sage-dark);
+  font-weight: 600;
+  border-top: 1px solid var(--cream-dark);
+}
+.overlay {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(42,34,24,0.4);
+  display: flex; align-items: center; justify-content: center; padding: 16px;
+}
+.modal-box {
+  background: var(--white); border-radius: 20px; padding: 24px;
+  width: 100%; max-width: 360px;
+  box-shadow: 0 20px 60px rgba(42,34,24,0.2);
+}
+</style>


### PR DESCRIPTION
## Summary
Riscontro sul form "Nuova pianta": la select nativa per scegliere la specie (~80 voci) era scomoda da usare, specialmente da mobile, e non c'era modo di aggiungere una specie non ancora censita senza uscire dal form.

- Sostituita la `<select>` con un campo di ricerca che filtra l'elenco specie in tempo reale mentre si digita (per nome, case-insensitive)
- Aggiunta un'opzione "＋ Aggiungi nuova specie" sempre visibile in fondo all'elenco filtrato, che apre un modale minimo: nome (obbligatorio), descrizione, esigenze di luce/acqua/terreno
- La nuova specie viene salvata in `specie.json` con una chiave slug generata dal nome (stesso schema delle voci esistenti: `nome`, `specie`, `descrizione`, `esigenze`, `alert: []`, `manutenzione` vuota) e selezionata automaticamente nel form pianta
- `manutenzione`/`alert` restano vuoti alla creazione (nessuna UI di modifica specie esiste ancora) — `useCure.js` gestisce già correttamente l'assenza di questi dati (nessuna cura urgente finché non vengono compilati)
- Blocco preventivo se lo slug generato coincide con una specie già esistente, con messaggio d'errore inline (stesso pattern già usato per le sottozone)

## Test plan
- [x] Build di produzione (`npm run build`) senza errori
- [x] Test Playwright: filtro live sull'elenco (~80 voci mostrate senza filtro, filtrate correttamente cercando "iberis"), selezione di una specie esistente, creazione di una nuova specie con prefill del nome digitato, auto-selezione della nuova specie nel form, salvataggio corretto della pianta con la nuova specie
- [x] Test Playwright: tentativo di creare una specie il cui slug coincide con una esistente → bloccato con errore inline, nessuna scrittura eseguita
- [x] Verifica visiva con screenshot del dropdown filtrato


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_