### PR TITLE
Aggiunge richiesta AI per consigli di concimazione

### DIFF
--- a/.claude/commands/elabora.md
+++ b/.claude/commands/elabora.md
@@ -6,6 +6,7 @@ Elabora le richieste pendenti dell'assistente AI dalla coda `public/data/richies
 2. Se non ce ne sono, rispondi "Nessuna richiesta in attesa" e fermati
 3. Per ogni richiesta in attesa:
    - Leggi `public/data/piante.json` e `public/data/specie.json` per avere il contesto del giardino
+   - Per `consiglio_concimazione`, leggi anche `public/data/concimi.json` (la dispensa dei concimi posseduti)
    - Se la richiesta contiene una foto in base64, analizzala
    - Genera una risposta dettagliata e pratica, in italiano, specifica per il giardino di Centinarola (Fano, clima mediterraneo collinare)
    - Aggiorna la richiesta nel JSON: `stato: "completata"`, `risposta: { messaggio: "...", elaborata: "<ISO date>" }`
@@ -21,5 +22,20 @@ La risposta deve essere:
 - Specifica per il tipo di richiesta:
   - `identifica_specie`: nome comune, nome scientifico, caratteristiche distintive
   - `consiglio_cura`: azione concreta con tempistiche per il clima marchigiano
+  - `consiglio_concimazione`: vedi procedura dedicata sotto
   - `diagnosi`: causa probabile + rimedio immediato
   - `altro`: risposta libera pertinente al contesto del giardino
+
+## Procedura per `consiglio_concimazione`
+
+L'utente chiede quale concime usare per una pianta (es. "che concime uso per la mia Passiflora?"). La logica di suggerimento nell'app (`src/composables/useConcimi.js`) confronta i concimi in dispensa con il fabbisogno NPK della specie **per rapporto**, non per concentrazione assoluta: usa lo stesso identico criterio, per coerenza con quanto l'utente vede già nelle Attività e nella scheda pianta.
+
+1. Identifica la pianta/specie di cui parla il messaggio (per nome comune, nome scientifico, zona/sottozona menzionata) in `piante.json`/`specie.json`. Se il messaggio è ambiguo (più piante corrispondono, o nessuna), chiedi di specificare nella risposta invece di indovinare.
+2. Determina la stagione corrente dalla data di elaborazione (primavera: mar-mag, estate: giu-ago, autunno: set-nov, inverno: dic-feb) e leggi `specie.manutenzione.npk[stagione]` (formato testo `"N-P-K"`, es. `"5-10-10"`, oppure `null`/assente = nessun fabbisogno specifico quella stagione).
+3. Se non c'è un fabbisogno NPK per la stagione corrente: rispondi che al momento questa pianta non ha necessità di concimazione specifiche (o segnalalo se manca del tutto il dato NPK per quella specie, invitando eventualmente ad aggiungerlo tramite il form specie).
+4. Altrimenti, confronta il rapporto richiesto con ciascun concime in `concimi.json` (campo `npk: {n, p, k}`):
+   - Normalizza entrambi i rapporti (dividi ciascun valore per la somma n+p+k, così un concime "5-10-5" e uno "10-20-10" risultano equivalenti — è la concentrazione assoluta a incidere sul dosaggio, non sull'idoneità)
+   - Calcola la distanza euclidea tra i due rapporti normalizzati
+   - Individua il concime con distanza minore
+5. Se la distanza minima supera 0.15 (soglia usata anche in `useConcimi.js`), oppure la dispensa è vuota: nessun concime è abbastanza vicino. Dillo esplicitamente nella risposta e indica il rapporto NPK ideale da cercare quando ne acquista uno nuovo.
+6. Altrimenti, indica per nome il concime consigliato dalla dispensa, il suo NPK, e conferma che è adatto alla stagione corrente.

--- a/src/views/AgenteView.vue
+++ b/src/views/AgenteView.vue
@@ -22,6 +22,7 @@
       <select v-model="nuovoTipo" class="form-input" style="margin-bottom:10px;">
         <option value="identifica_specie">🌿 Identifica specie da foto</option>
         <option value="consiglio_cura">💧 Consiglio per cura</option>
+        <option value="consiglio_concimazione">🌱 Consiglio concimazione</option>
         <option value="diagnosi">🔍 Diagnosi problema</option>
         <option value="altro">💬 Altro</option>
       </select>


### PR DESCRIPTION
## Summary
Estende l'Assistente AI (coda `richieste-agente.json`) con un nuovo tipo di richiesta per chiedere consigli di concimazione, es. "che concime uso per la mia Passiflora?".

- `AgenteView.vue`: nuova opzione "🌱 Consiglio concimazione" nel selettore tipo richiesta
- `.claude/commands/elabora.md`: nuova procedura dedicata per questo tipo, che replica esattamente la stessa logica di matching già usata da `src/composables/useConcimi.js` per il suggerimento live in Attività/scheda pianta (confronto per rapporto N:P:K normalizzato — non concentrazione assoluta —, distanza euclidea, soglia 0.15). Così la risposta ricevuta via coda e il suggerimento mostrato altrove nell'app non si contraddicono mai tra loro.
- Se non c'è un fabbisogno NPK per la specie/stagione, o nessun concime in dispensa è abbastanza vicino, la procedura istruisce a dirlo esplicitamente invece di forzare un consiglio mediocre.

## Test plan
- [x] Build di produzione (`npm run build`) senza errori
- [x] Test Playwright: nuova opzione presente nel selettore, invio di una richiesta di tipo `consiglio_concimazione` salvata correttamente in coda con lo stato atteso, card visibile nello storico


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_