### PR TITLE
Estende identifica_specie con una proposta di fabbisogno NPK

### DIFF
--- a/.claude/commands/elabora.md
+++ b/.claude/commands/elabora.md
@@ -20,11 +20,26 @@ La risposta deve essere:
 - In italiano
 - Pratica e concisa (max 200 parole)
 - Specifica per il tipo di richiesta:
-  - `identifica_specie`: nome comune, nome scientifico, caratteristiche distintive
+  - `identifica_specie`: vedi procedura dedicata sotto
   - `consiglio_cura`: azione concreta con tempistiche per il clima marchigiano
   - `consiglio_concimazione`: vedi procedura dedicata sotto
   - `diagnosi`: causa probabile + rimedio immediato
   - `altro`: risposta libera pertinente al contesto del giardino
+
+## Procedura per `identifica_specie`
+
+Oltre a nome comune, nome scientifico e caratteristiche distintive dalla foto, includi nella risposta una proposta di **fabbisogno NPK per stagione**, nello stesso formato usato in `specie.json` (`"N-P-K"`, es. `"10-5-5"`, o assenza di valore per le stagioni senza necessità specifica) — così, se l'utente aggiunge poi la specie tramite il form "nuova specie", ha già i valori pronti da inserire nella tabella invece di dover cercare altrove.
+
+- Prima di proporre un valore, controlla se la specie identificata (o una molto simile) esiste già in `specie.json`: se sì, usa lo stesso NPK già presente lì invece di inventarne uno diverso, per coerenza tra voci della stessa specie/categoria.
+- Altrimenti, assegna il fabbisogno in base alla categoria botanica della pianta (lo stesso criterio già usato per popolare `specie.json`):
+  - fogliame da interno → azoto prevalente (es. "20-10-10")
+  - succulente/grasse → fabbisogno minimo, solo primavera (es. "5-5-5")
+  - aromatiche mediterranee → scarso e bilanciato (es. "5-5-5")
+  - aromatiche da foglia → azoto moderato (es. "10-5-5")
+  - fiorite/perenni ornamentali → fosforo prevalente (es. "5-10-10")
+  - da frutto → potassio prevalente (es. "5-10-15")
+  - specie note per sensibilità a un nutriente specifico (es. l'avocado teme l'eccesso di fosforo) → tienine conto esplicitamente, preferendo un profilo azotato basso in fosforo invece del generico bilanciato
+- Se non hai elementi sufficienti per una stima ragionevole (specie molto incerta o poco nota), ometti la proposta NPK invece di inventarne una a caso, e dillo nella risposta.
 
 ## Procedura per `consiglio_concimazione`
 


### PR DESCRIPTION
## Summary
Ultimo pezzo del piano concimazione: quando l'Assistente identifica una specie da foto (`identifica_specie`), la risposta ora include anche una proposta di fabbisogno NPK per stagione, oltre a nome comune/scientifico e caratteristiche distintive.

- Riusa l'NPK già presente in `specie.json` se la specie identificata (o una molto simile) esiste già, invece di proporne uno diverso per la stessa pianta
- Altrimenti assegna il fabbisogno per categoria botanica, con lo stesso criterio già usato per il backfill delle ~80 specie esistenti (fogliame da interno, succulente, aromatiche, fiorite, da frutto, ecc.), tenendo conto di sensibilità note a nutrienti specifici (es. l'avocado teme l'eccesso di fosforo — coerente con la correzione appena fatta sulla sua scheda)
- Se la specie è troppo incerta per una stima ragionevole, istruisce a ometterla invece di inventarla

Così l'utente ha già i valori pronti da inserire se poi aggiunge la specie tramite il form, invece di doverli cercare o chiedermeli a parte (come successo finora per Passiflora e Avocado).

Modifica solo a `.claude/commands/elabora.md` (istruzioni testuali, nessun codice eseguibile).

## Test plan
- Nessuna verifica automatica applicabile: è un file di istruzioni per l'elaborazione futura delle richieste, non codice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_