### PR TITLE
Aggiunge la Calathea rattlesnake in Casa/Ingresso

### DIFF
--- a/public/data/piante.json
+++ b/public/data/piante.json
@@ -1301,5 +1301,17 @@
     "impianto": "2026-06-25",
     "note": "",
     "ultima_cura": {}
+  },
+  "calathea-1784629447642": {
+    "specie": "calathea",
+    "zona": "Casa",
+    "sottozona": "Ingresso",
+    "varieta": "Rattlesnake (Goeppertia insignis / Calathea lancifolia)",
+    "impianto": "2026-07-21",
+    "note": "Foglie lunghe e strette con macchie ovali verde scuro e pagina inferiore rosso-violacea. Bordi delle foglie leggermente seccati (aria secca/acqua calcarea). Identificata il 21/07/2026 dall'assistente AI a partire da una foto.",
+    "ultima_cura": {
+      "irrigazione": "2026-07-21",
+      "concimazione": "2026-07-21"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Aggiunge in `piante.json` la Calathea rattlesnake (Goeppertia insignis / Calathea lancifolia) in zona Casa/Ingresso, identificata da foto, riutilizzando il profilo specie `calathea` già presente in catalogo

## Test plan
- [x] Verificato che il JSON risultante sia valido (`jq` parse OK)
- [x] Verificato che non ci siano duplicati con le piante già presenti in Casa/Ingresso


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4aQMagxU1bcgqwt1fHpp)_