### PR TITLE
Mostra il fabbisogno NPK quando nessun concime in dispensa è adatto

### DIFF
--- a/src/views/PiantaView.vue
+++ b/src/views/PiantaView.vue
@@ -68,7 +68,7 @@
                 🌱 Consigliato: {{ suggerimentoConcime.nome }} ({{ suggerimentoConcime.npk.n }}-{{ suggerimentoConcime.npk.p }}-{{ suggerimentoConcime.npk.k }})
               </div>
               <div v-else-if="tipo === 'concimazione' && fabbisognoNpk && !suggerimentoConcime" style="font-size:11px;color:var(--ink-faint);margin-top:2px;">
-                Nessun concime adatto in dispensa
+                Nessun concime adatto in dispensa (fabbisogno {{ fabbisognoNpk }})
               </div>
             </div>
             <button @click="registraCura(tipo)" :disabled="salvando === tipo" class="btn btn-sage"


### PR DESCRIPTION
## Summary
Quando nessun concime in dispensa è abbastanza vicino al fabbisogno di una pianta, la scheda pianta mostrava solo "Nessun concime adatto in dispensa" senza indicare quale rapporto NPK servirebbe — bisognava controllare la specie a parte per saperlo. Ora il valore richiesto è mostrato direttamente accanto all'avviso, es. "Nessun concime adatto in dispensa (fabbisogno 5-10-15)".

Modifica minima: `fabbisognoNpk` era già calcolato e disponibile in `PiantaView.vue`, semplicemente non veniva mostrato in questo ramo del template.

## Test plan
- [x] Build di produzione (`npm run build`) senza errori
- [x] Verificato su una pianta reale senza match (Avocado, fabbisogno 10-5-5): il testo "Nessun concime adatto in dispensa (fabbisogno 10-5-5)" compare correttamente nella scheda cure


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_