### PR TITLE
Aggiunge il dettaglio orario di oggi alla vista Meteo

### DIFF
--- a/src/composables/useMeteo.js
+++ b/src/composables/useMeteo.js
@@ -22,20 +22,22 @@ const WMO_LABEL = {
 }
 
 export function useMeteo() {
-  const giorni   = ref([])
-  const oggi     = ref(null)
-  const loading  = ref(false)
-  const errore   = ref(null)
+  const giorni      = ref([])
+  const oggi        = ref(null)
+  const orarieOggi  = ref([])
+  const loading     = ref(false)
+  const errore      = ref(null)
 
   async function carica(lat, lon, days = 7) {
     loading.value = true
     errore.value  = null
     try {
-      const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,windspeed_10m_max&forecast_days=${days}&timezone=Europe/Rome`
+      const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,windspeed_10m_max&hourly=temperature_2m,precipitation_probability,weathercode,windspeed_10m&forecast_days=${days}&timezone=Europe/Rome`
       const res  = await fetch(url)
       if (!res.ok) throw new Error('Errore API meteo')
       const raw  = await res.json()
       const d    = raw.daily
+      const h    = raw.hourly
 
       giorni.value = d.time.map((data, i) => ({
         data,
@@ -49,6 +51,16 @@ export function useMeteo() {
         vento: Math.round(d.windspeed_10m_max[i]),
       }))
       oggi.value = giorni.value[0] ?? null
+
+      orarieOggi.value = h?.time ? h.time.slice(0, 24).map((ora, i) => ({
+        ora,
+        label: new Date(ora).toLocaleTimeString('it-IT', { hour:'2-digit', minute:'2-digit' }),
+        icona: WMO[h.weathercode[i]] ?? '🌡️',
+        descrizione: WMO_LABEL[h.weathercode[i]] ?? '',
+        temp: Math.round(h.temperature_2m[i]),
+        pioggiaProb: h.precipitation_probability?.[i] ?? null,
+        vento: Math.round(h.windspeed_10m[i]),
+      })) : []
     } catch (e) {
       errore.value = e.message
     } finally {
@@ -56,5 +68,5 @@ export function useMeteo() {
     }
   }
 
-  return { giorni, oggi, loading, errore, carica }
+  return { giorni, oggi, orarieOggi, loading, errore, carica }
 }

--- a/src/composables/useMeteo.js
+++ b/src/composables/useMeteo.js
@@ -32,7 +32,7 @@ export function useMeteo() {
     loading.value = true
     errore.value  = null
     try {
-      const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,windspeed_10m_max&hourly=temperature_2m,precipitation_probability,weathercode,windspeed_10m&forecast_days=${days}&timezone=Europe/Rome`
+      const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,windspeed_10m_max&hourly=temperature_2m,precipitation_probability,weathercode,windspeed_10m&forecast_days=${days}&timezone=auto`
       const res  = await fetch(url)
       if (!res.ok) throw new Error('Errore API meteo')
       const raw  = await res.json()
@@ -54,7 +54,7 @@ export function useMeteo() {
 
       orarieOggi.value = h?.time ? h.time.slice(0, 24).map((ora, i) => ({
         ora,
-        label: new Date(ora).toLocaleTimeString('it-IT', { hour:'2-digit', minute:'2-digit' }),
+        label: ora.slice(11, 16),
         icona: WMO[h.weathercode[i]] ?? '🌡️',
         descrizione: WMO_LABEL[h.weathercode[i]] ?? '',
         temp: Math.round(h.temperature_2m[i]),

--- a/src/views/MeteoView.vue
+++ b/src/views/MeteoView.vue
@@ -16,20 +16,37 @@
       <p>{{ errore }}</p>
     </div>
 
-    <div v-else style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:12px;">
-      <div v-for="(g, i) in giorni" :key="g.data"
-        class="card"
-        :class="{ 'card-oggi': i === 0 }"
-        style="padding:18px;text-align:center;">
-        <div class="meteo-label">{{ i === 0 ? 'Oggi' : g.label }}</div>
-        <div style="font-size:40px;margin:10px 0;">{{ g.icona }}</div>
-        <div style="font-size:12px;color:var(--ink-soft);margin-bottom:8px;">{{ g.descrizione }}</div>
-        <div style="font-weight:600;font-size:15px;">{{ g.tMax }}° / {{ g.tMin }}°</div>
-        <div style="font-size:11px;color:var(--ink-soft);margin-top:4px;">
-          💧 {{ g.pioggia }} mm · 💨 {{ g.vento }} km/h
+    <template v-else>
+      <div v-if="orarieOggi.length" class="card" style="padding:16px;margin-bottom:16px;">
+        <p class="section-label" style="margin-bottom:10px;">Oggi, ora per ora</p>
+        <div style="display:flex;gap:10px;overflow-x:auto;padding-bottom:4px;">
+          <div v-for="o in orarieOggi" :key="o.ora"
+            class="ora-box"
+            :class="{ 'ora-corrente': oraCorrente(o) }"
+            style="flex-shrink:0;text-align:center;padding:8px 10px;border-radius:12px;min-width:56px;">
+            <div style="font-size:11px;color:var(--ink-soft);">{{ o.label }}</div>
+            <div style="font-size:22px;margin:4px 0;">{{ o.icona }}</div>
+            <div style="font-size:12px;font-weight:600;">{{ o.temp }}°</div>
+            <div v-if="o.pioggiaProb !== null" style="font-size:10px;color:var(--ink-faint);margin-top:2px;">💧 {{ o.pioggiaProb }}%</div>
+          </div>
         </div>
       </div>
-    </div>
+
+      <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:12px;">
+        <div v-for="(g, i) in giorni" :key="g.data"
+          class="card"
+          :class="{ 'card-oggi': i === 0 }"
+          style="padding:18px;text-align:center;">
+          <div class="meteo-label">{{ i === 0 ? 'Oggi' : g.label }}</div>
+          <div style="font-size:40px;margin:10px 0;">{{ g.icona }}</div>
+          <div style="font-size:12px;color:var(--ink-soft);margin-bottom:8px;">{{ g.descrizione }}</div>
+          <div style="font-weight:600;font-size:15px;">{{ g.tMax }}° / {{ g.tMin }}°</div>
+          <div style="font-size:11px;color:var(--ink-soft);margin-top:4px;">
+            💧 {{ g.pioggia }} mm · 💨 {{ g.vento }} km/h
+          </div>
+        </div>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -38,13 +55,17 @@ import { onMounted } from 'vue'
 import { useMeteo } from '@/composables/useMeteo'
 import { useDatiStore } from '@/stores/dati'
 
-const { giorni, loading, errore, carica } = useMeteo()
+const { giorni, orarieOggi, loading, errore, carica } = useMeteo()
 const store = useDatiStore()
+
+function oraCorrente(o) {
+  return new Date(o.ora).getHours() === new Date().getHours()
+}
 
 onMounted(async () => {
   await store.caricaTutto()
   const s = store.settings
-  carica(s?.lat ?? 43.8309, s?.lon ?? 12.9860)
+  carica(s?.location?.lat ?? 43.8309, s?.location?.lon ?? 12.9860)
 })
 </script>
 
@@ -54,4 +75,6 @@ onMounted(async () => {
   font-family: var(--font-serif); font-size: 13px;
   font-weight: 600; color: var(--ink-mid); text-transform: capitalize;
 }
+.ora-box { background: var(--cream); }
+.ora-corrente { background: var(--gold-pale); border: 1px solid var(--gold-light); }
 </style>

--- a/src/views/MeteoView.vue
+++ b/src/views/MeteoView.vue
@@ -59,7 +59,10 @@ const { giorni, orarieOggi, loading, errore, carica } = useMeteo()
 const store = useDatiStore()
 
 function oraCorrente(o) {
-  return new Date(o.ora).getHours() === new Date().getHours()
+  const d = new Date()
+  const oggiStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  const oraStr = String(d.getHours()).padStart(2, '0')
+  return o.ora === `${oggiStr}T${oraStr}:00`
 }
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
- Aggiunge una striscia orizzontale scorrevole con temperatura, icona meteo e probabilità di pioggia ora per ora per la giornata odierna, sopra il riepilogo dei 7 giorni (invariato)
- Spiega/risolve il disallineamento notato tra la webapp e Open-Meteo.com: il riepilogo giornaliero mostra un codice meteo aggregato per l'intera giornata (24h), mentre Open-Meteo.com in home mostra le condizioni "adesso" — con il dettaglio orario ora si può vedere l'evoluzione ora per ora invece del solo aggregato
- Corregge la lettura delle coordinate in `MeteoView.vue`: leggeva `s?.lat`/`s?.lon` invece di `s?.location?.lat`/`s?.location?.lon` (struttura reale di `settings.json`), quindi usava sempre il fallback hardcoded nel componente

## Test plan
- [x] `npm run build` completato senza errori
- [x] Test Playwright su preview build con risposta Open-Meteo mockata (24 ore + 7 giorni): verificate 24 fasce orarie mostrate correttamente con icona/temperatura/probabilità pioggia, verificato che le 7 card giornaliere restano invariate
- [x] Verificato visivamente via screenshot che la striscia oraria è scorrevole e non rompe il layout mobile (390px)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_