### PR TITLE
Forza 3 colonne per i giorni successivi su desktop

### DIFF
--- a/src/views/MeteoView.vue
+++ b/src/views/MeteoView.vue
@@ -32,7 +32,7 @@
         </div>
       </div>
 
-      <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:12px;">
+      <div class="meteo-giorni-grid">
         <div v-for="g in giorniSuccessivi" :key="g.data"
           class="card"
           style="padding:18px;text-align:center;">
@@ -97,4 +97,12 @@ onMounted(async () => {
 }
 .ora-box { background: var(--cream); }
 .ora-corrente { background: var(--gold-pale); border: 1px solid var(--gold-light); }
+.meteo-giorni-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+@media (min-width: 641px) {
+  .meteo-giorni-grid { grid-template-columns: repeat(3, 1fr); }
+}
 </style>


### PR DESCRIPTION
## Summary
- Su desktop i 6 box dei giorni successivi si disponevano 5 in una riga e 1 nella successiva (grid `auto-fill`)
- Aggiunge una classe `.meteo-giorni-grid` con una regola a 3 colonne fisse da 641px in su (stesso breakpoint desktop già usato in `BottomNav.vue`/`NavBar.vue`/`StatusBar.vue`), ottenendo 2 righe da 3 box
- Su mobile il comportamento resta invariato (auto-fill)

## Test plan
- [x] `npm run build` completato senza errori
- [x] Test Playwright su preview build a 1200px: verificato `grid-template-columns` risolto in 3 colonne (2 righe da 3)
- [x] Stesso test a 390px: verificato che l'auto-fill resta invariato
- [x] Verificato visivamente via screenshot il layout desktop


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_