### PR TITLE
Aggiunge avvisi di condizioni meteo avverse

### DIFF
--- a/src/composables/useMeteo.js
+++ b/src/composables/useMeteo.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
 const WMO = {
   0:'☀️', 1:'🌤️', 2:'⛅', 3:'☁️',
@@ -19,6 +19,18 @@ const WMO_LABEL = {
   71:'Neve leggera', 73:'Neve moderata', 75:'Neve intensa',
   80:'Rovesci leggeri', 81:'Rovesci moderati', 82:'Rovesci intensi',
   95:'Temporale', 96:'Temporale con grandine', 99:'Temporale forte',
+}
+
+const CODICI_TEMPORALE = [95, 96, 99]
+
+function valutaAvvisi(g) {
+  const avvisi = []
+  if (g.tMin <= 3) avvisi.push({ icona:'❄️', testo:`Rischio gelo (min ${g.tMin}°)` })
+  if (g.tMax >= 35) avvisi.push({ icona:'🥵', testo:`Caldo estremo (max ${g.tMax}°)` })
+  if (g.vento >= 40) avvisi.push({ icona:'💨', testo:`Vento forte (${g.vento} km/h)` })
+  if (CODICI_TEMPORALE.includes(g.codice)) avvisi.push({ icona:'⛈️', testo:'Temporale previsto' })
+  else if (parseFloat(g.pioggia) >= 20) avvisi.push({ icona:'🌧️', testo:`Pioggia intensa (${g.pioggia} mm)` })
+  return avvisi
 }
 
 export function useMeteo() {
@@ -68,5 +80,9 @@ export function useMeteo() {
     }
   }
 
-  return { giorni, oggi, orarieOggi, loading, errore, carica }
+  const avvisi = computed(() => giorni.value.flatMap((g, i) =>
+    valutaAvvisi(g).map(a => ({ ...a, giorno: i === 0 ? 'Oggi' : g.label, key: `${g.data}-${a.testo}` }))
+  ))
+
+  return { giorni, oggi, orarieOggi, avvisi, loading, errore, carica }
 }

--- a/src/views/MeteoView.vue
+++ b/src/views/MeteoView.vue
@@ -17,6 +17,15 @@
     </div>
 
     <template v-else>
+      <div v-if="avvisi.length" class="card" style="padding:14px 16px;border-color:var(--rose-light);background:var(--rose-pale);margin-bottom:16px;">
+        <p style="font-size:12px;font-weight:600;color:var(--rose-dark);margin-bottom:8px;">⚠ Condizioni avverse in arrivo</p>
+        <div style="display:flex;flex-direction:column;gap:6px;">
+          <div v-for="a in avvisi" :key="a.key" style="font-size:13px;color:var(--rose-dark);">
+            {{ a.icona }} <strong>{{ a.giorno }}</strong> — {{ a.testo }}
+          </div>
+        </div>
+      </div>
+
       <div v-if="orarieDaAdesso.length" class="card" style="padding:16px;margin-bottom:16px;">
         <p class="section-label" style="margin-bottom:10px;">Oggi, ora per ora</p>
         <div style="display:flex;gap:10px;overflow-x:auto;padding-bottom:4px;">
@@ -54,7 +63,7 @@ import { onMounted, onUnmounted, ref, computed } from 'vue'
 import { useMeteo } from '@/composables/useMeteo'
 import { useDatiStore } from '@/stores/dati'
 
-const { giorni, orarieOggi, loading, errore, carica } = useMeteo()
+const { giorni, orarieOggi, avvisi, loading, errore, carica } = useMeteo()
 const store = useDatiStore()
 
 const giorniSuccessivi = computed(() => giorni.value.slice(1))


### PR DESCRIPTION
## Summary
- Nuova sezione in cima alla pagina Meteo che elenca i giorni (incluso oggi) con condizioni avverse in arrivo, senza nuove chiamate API (riusa i dati giornalieri già richiesti)
- Soglie: rischio gelo (min ≤ 3°), caldo estremo (max ≥ 35°), vento forte (≥ 40 km/h), temporale (codice WMO 95/96/99, ha priorità sulla pioggia) o pioggia intensa (≥ 20mm/giorno)
- Nessun avviso mostrato quando le condizioni sono normali (sezione nascosta)
- Pensata soprattutto per il gelo, dato che la maggior parte delle piante sensibili al freddo del giardino è in piena terra e quindi non "aggirabile" spostandola — l'obiettivo è che l'allerta sia visibile subito invece di doverla dedurre dalle minime nelle card giornaliere

## Test plan
- [x] `npm run build` completato senza errori
- [x] Test Playwright con dati mockati che attivano tutti e 5 i tipi di avviso: verificato testo ed etichette corrette, verificato che "Temporale previsto" ha priorità su "Pioggia intensa" quando il codice WMO indica temporale
- [x] Test Playwright con dati "normali": verificato che la sezione avvisi non compare
- [x] Verificato visivamente via screenshot lo stile (coerente con il banner urgenze già usato in PiantaView)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_