### PR TITLE
Sopprime l'urgenza di irrigazione per le piante esterne se piove

### DIFF
--- a/src/composables/useCure.js
+++ b/src/composables/useCure.js
@@ -18,7 +18,16 @@ function parseGiorni(testo) {
   return match ? parseInt(match[1]) : null
 }
 
-export function valutaCura(pianta, specie, tipo) {
+// Pioggia cumulata (oggi + domani) considerata sufficiente da sostituire un'irrigazione manuale
+const SOGLIA_PIOGGIA_MM = 5
+
+function pioggiaInArrivo(meteoGiorni) {
+  if (!Array.isArray(meteoGiorni) || !meteoGiorni.length) return false
+  const cumulata = meteoGiorni.slice(0, 2).reduce((tot, g) => tot + (parseFloat(g.pioggia) || 0), 0)
+  return cumulata >= SOGLIA_PIOGGIA_MM
+}
+
+export function valutaCura(pianta, specie, tipo, contesto = {}) {
   const stagCorrente = stagione()
   const manutenzione = specie?.manutenzione?.[tipo]?.[stagCorrente]
   if (!manutenzione || manutenzione === 'mai' || manutenzione === 'non necessario') {
@@ -28,6 +37,10 @@ export function valutaCura(pianta, specie, tipo) {
   const intervallo = parseGiorni(manutenzione)
   const ultimaStr  = pianta?.ultima_cura?.[tipo]
   if (!intervallo) return { urgente: false, label: manutenzione, giorni: null }
+
+  if (tipo === 'irrigazione' && contesto.esterno && pioggiaInArrivo(contesto.meteo)) {
+    return { urgente: false, label: 'irrigazione — pioggia prevista, salta', giorni: null }
+  }
 
   if (!ultimaStr) {
     return { urgente: true, label: `${tipo} — mai registrata`, giorni: Infinity }
@@ -50,8 +63,8 @@ export function valutaCura(pianta, specie, tipo) {
   }
 }
 
-export function cureUrgentiPianta(pianta, specie) {
+export function cureUrgentiPianta(pianta, specie, contesto) {
   return ['irrigazione','concimazione','potatura']
-    .map(tipo => ({ tipo, ...valutaCura(pianta, specie, tipo) }))
+    .map(tipo => ({ tipo, ...valutaCura(pianta, specie, tipo, contesto) }))
     .filter(c => c.urgente)
 }

--- a/src/stores/dati.js
+++ b/src/stores/dati.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { useMeteo } from '@/composables/useMeteo'
 
 const BASE = import.meta.env.BASE_URL
 
@@ -17,6 +18,7 @@ export const useDatiStore = defineStore('dati', () => {
   const progetti  = ref(null)
   const settings  = ref(null)
   const concimi   = ref(null)
+  const meteo     = ref(null)
   const loading   = ref(false)
   const errore    = ref(null)
 
@@ -40,6 +42,18 @@ export const useDatiStore = defineStore('dati', () => {
     } finally {
       loading.value = false
     }
+
+    // Previsioni meteo (solo oggi/domani): usate da useCure per sospendere
+    // l'irrigazione delle piante esterne quando è prevista pioggia sufficiente.
+    // Un eventuale errore di rete resta silenzioso: senza dati meteo affidabili
+    // le cure vengono valutate come se non piovesse (nessuna soppressione).
+    const lat = settings.value?.location?.lat
+    const lon = settings.value?.location?.lon
+    if (lat && lon) {
+      const { giorni, carica } = useMeteo()
+      await carica(lat, lon, 2)
+      meteo.value = giorni.value
+    }
   }
 
   async function aggiorna() {
@@ -47,5 +61,5 @@ export const useDatiStore = defineStore('dati', () => {
     await caricaTutto()
   }
 
-  return { piante, specie, zone, sottozone, progetti, settings, concimi, loading, errore, caricaTutto, aggiorna }
+  return { piante, specie, zone, sottozone, progetti, settings, concimi, meteo, loading, errore, caricaTutto, aggiorna }
 })

--- a/src/views/AttivitaView.vue
+++ b/src/views/AttivitaView.vue
@@ -80,11 +80,13 @@ const attivita = computed(() => {
   if (!store.piante) return []
   const stagioneCorrente = stagione()
   const items = []
+  const contestoMeteo = { meteo: store.meteo }
   for (const [id, p] of Object.entries(store.piante)) {
     const sp = store.specie?.[p.specie] ?? null
     const nomeSpecie = sp?.nome ?? p.specie
+    const contesto = { ...contestoMeteo, esterno: store.zone?.[p.zona]?.tipo === 'esterno' }
     for (const tipo of ['irrigazione', 'concimazione', 'potatura']) {
-      const c = valutaCura(p, sp, tipo)
+      const c = valutaCura(p, sp, tipo, contesto)
       if (c.giorni !== null) {
         const suggerimento = tipo === 'concimazione'
           ? concimeConsigliato(sp?.manutenzione?.npk?.[stagioneCorrente], store.concimi)

--- a/src/views/PiantaView.vue
+++ b/src/views/PiantaView.vue
@@ -62,7 +62,7 @@
             <div>
               <div style="font-size:13px;font-weight:500;text-transform:capitalize;">{{ tipo }}</div>
               <div style="font-size:11px;color:var(--ink-soft);margin-top:2px;">
-                {{ valutaCura(pianta, specie, tipo).label ?? 'Non configurata' }}
+                {{ valutaCura(pianta, specie, tipo, contestoCura).label ?? 'Non configurata' }}
               </div>
               <div v-if="tipo === 'concimazione' && fabbisognoNpk && suggerimentoConcime" style="font-size:11px;color:var(--sage-dark);margin-top:2px;">
                 🌱 Consigliato: {{ suggerimentoConcime.nome }} ({{ suggerimentoConcime.npk.n }}-{{ suggerimentoConcime.npk.p }}-{{ suggerimentoConcime.npk.k }})
@@ -157,8 +157,13 @@ const specie = computed(() =>
   pianta.value ? (store.specie?.[pianta.value.specie] ?? null) : null
 )
 
+const contestoCura = computed(() => ({
+  esterno: store.zone?.[pianta.value?.zona]?.tipo === 'esterno',
+  meteo: store.meteo,
+}))
+
 const cureUrgenti = computed(() =>
-  pianta.value ? cureUrgentiPianta(pianta.value, specie.value) : []
+  pianta.value ? cureUrgentiPianta(pianta.value, specie.value, contestoCura.value) : []
 )
 
 const fabbisognoNpk = computed(() => specie.value?.manutenzione?.npk?.[stagione()] ?? null)


### PR DESCRIPTION
## Summary
- Prima feature della coppia discussa in chat (collegare il meteo alle cure): sopprime l'urgenza di irrigazione per le piante in zone esterne quando è prevista pioggia sufficiente
- Lo store (`stores/dati.js`) carica ora anche le previsioni meteo (oggi + domani, stesse coordinate di `settings.json`) una sola volta insieme agli altri dati all'avvio dell'app
- `useCure.js`: `valutaCura`/`cureUrgentiPianta` accettano un contesto opzionale `{ esterno, meteo }`; se la pianta è esterna e la pioggia cumulata prevista nelle prossime 48h è ≥ 5mm, l'irrigazione non risulta urgente e mostra "pioggia prevista, salta" invece di "scaduta"/"mai registrata"
- Concimazione, potatura e le piante in zone interne non sono toccate
- Se il fetch meteo fallisce o mancano le coordinate, il contesto resta senza dati meteo e il comportamento è invariato rispetto a prima (nessuna soppressione senza conferma di pioggia — fail-safe)
- Aggiornati i due punti di consumo esistenti: `AttivitaView.vue` (elenco urgenze aggregato) e `PiantaView.vue` (banner urgenze + sezione "Stato cure")

## Test plan
- [x] `npm run build` completato senza errori
- [x] Test Playwright con fixture controllate (dati locali + risposta Open-Meteo mockati) e due scenari:
  - Con pioggia abbondante (8mm oggi + 4mm domani): la pianta esterna scaduta da 7 giorni sparisce dalle urgenze in Attività e la scheda pianta mostra "irrigazione — pioggia prevista, salta"; la pianta interna, identica ma in zona interna, resta "scaduta 7 gg fa" in entrambi gli scenari (invariata)
  - Senza pioggia: la pianta esterna torna a comparire correttamente tra le urgenze come "scaduta 7 gg fa"


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_