### PR TITLE
Completa la galleria: eliminazione foto, foto in scheda pianta, thumbnail, cascade delete

### DIFF
--- a/src/components/LightboxFoto.vue
+++ b/src/components/LightboxFoto.vue
@@ -1,0 +1,49 @@
+<template>
+  <Teleport to="body">
+    <div v-if="foto" @click.self="$emit('chiudi')"
+      style="position:fixed;inset:0;z-index:300;background:rgba(0,0,0,0.94);display:flex;flex-direction:column;align-items:center;justify-content:center;">
+
+      <!-- Header -->
+      <div style="position:absolute;top:0;left:0;right:0;padding:14px 16px;display:flex;align-items:center;gap:10px;">
+        <span style="font-size:13px;font-weight:600;color:rgba(255,255,255,0.9);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ titolo }}</span>
+        <span style="font-size:11px;color:rgba(255,255,255,0.5);">{{ foto.dataEstesa }}</span>
+        <button @click="$emit('elimina')" aria-label="Elimina foto" title="Elimina foto"
+          style="background:rgba(255,255,255,0.12);border:none;border-radius:50%;width:32px;height:32px;color:white;font-size:15px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;">🗑️</button>
+        <button @click="$emit('chiudi')" aria-label="Chiudi"
+          style="background:rgba(255,255,255,0.12);border:none;border-radius:50%;width:32px;height:32px;color:white;font-size:18px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;">×</button>
+      </div>
+
+      <!-- Immagine -->
+      <img :src="foto.url" :alt="foto.nome"
+        style="max-width:100%;max-height:calc(100vh - 100px);object-fit:contain;border-radius:8px;padding:56px 8px 44px;">
+
+      <!-- Navigazione prev/next -->
+      <button v-if="haPrecedente" @click="$emit('naviga', -1)" aria-label="Foto precedente"
+        style="position:absolute;left:8px;top:50%;transform:translateY(-50%);background:rgba(255,255,255,0.12);border:none;border-radius:50%;width:40px;height:40px;color:white;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;">‹</button>
+      <button v-if="haSuccessivo" @click="$emit('naviga', 1)" aria-label="Foto successiva"
+        style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:rgba(255,255,255,0.12);border:none;border-radius:50%;width:40px;height:40px;color:white;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;">›</button>
+
+      <!-- Contatore -->
+      <div v-if="indice != null && totale != null" style="position:absolute;bottom:14px;left:0;right:0;text-align:center;">
+        <span style="font-size:11px;color:rgba(255,255,255,0.4);">{{ indice + 1 }} / {{ totale }}</span>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+// Lightbox condiviso tra GalleryView.vue e PiantaView.vue: mostra una foto a
+// piena pagina con navigazione prev/next ed eliminazione. Non contiene una
+// propria conferma di eliminazione: emette solo "elimina" e lascia che il
+// chiamante gestisca ModalConferma, come fanno già tutti gli altri flussi di
+// cancellazione dell'app (nessun pattern nuovo da imparare).
+defineProps({
+  foto:         { type: Object,  default: null },
+  titolo:       { type: String,  default: '' },
+  haPrecedente: { type: Boolean, default: false },
+  haSuccessivo: { type: Boolean, default: false },
+  indice:       { type: Number,  default: null },
+  totale:       { type: Number,  default: null },
+})
+defineEmits(['chiudi', 'naviga', 'elimina'])
+</script>

--- a/src/components/ModalConferma.vue
+++ b/src/components/ModalConferma.vue
@@ -27,7 +27,7 @@ defineEmits(['conferma', 'annulla'])
 
 <style scoped>
 .overlay {
-  position: fixed; inset: 0; z-index: 200;
+  position: fixed; inset: 0; z-index: 400;
   background: rgba(42,34,24,0.4);
   display: flex; align-items: center; justify-content: center;
   padding: 16px;

--- a/src/components/PiantaRiga.vue
+++ b/src/components/PiantaRiga.vue
@@ -1,9 +1,11 @@
 <template>
   <RouterLink :to="`/piante/${pianta.id}`" class="card hover-card"
     style="display:flex;align-items:center;gap:14px;padding:12px 16px;text-decoration:none;color:inherit;">
-    <div style="width:48px;height:48px;border-radius:14px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:22px;"
+    <div style="width:48px;height:48px;border-radius:14px;flex-shrink:0;position:relative;display:flex;align-items:center;justify-content:center;font-size:22px;overflow:hidden;"
       :style="urgente ? 'background:var(--rose-pale)' : 'background:var(--sage-pale)'">
-      {{ urgente ? '⚠️' : '🌿' }}
+      <img v-if="thumbUrl" :src="thumbUrl" alt="" style="width:100%;height:100%;object-fit:cover;" loading="lazy">
+      <template v-else>{{ urgente ? '⚠️' : '🌿' }}</template>
+      <span v-if="thumbUrl && urgente" style="position:absolute;bottom:-2px;right:-2px;font-size:13px;">⚠️</span>
     </div>
     <div style="flex:1;min-width:0;">
       <div class="title-serif" style="font-size:14px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
@@ -31,8 +33,9 @@ import { useDatiStore } from '@/stores/dati'
 import { cureUrgentiPianta } from '@/composables/useCure'
 
 const props = defineProps({
-  pianta:  { type: Object,  required: true },
-  urgente: { type: Boolean, default: false },
+  pianta:   { type: Object,  required: true },
+  urgente:  { type: Boolean, default: false },
+  thumbUrl: { type: String,  default: null },
 })
 defineEmits(['elimina'])
 

--- a/src/composables/useApi.js
+++ b/src/composables/useApi.js
@@ -117,6 +117,20 @@ export function useApi() {
     return res.json()
   }
 
+  async function deleteFile(repoPath, sha, message = 'Elimina file') {
+    const url = `https://api.github.com/repos/${OWNER}/${REPO}/contents/${repoPath}`
+    const res = await fetch(url, {
+      method: 'DELETE',
+      headers: getHeaders(),
+      body: JSON.stringify({ message, sha, branch: BRANCH }),
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.message || 'Errore eliminazione file')
+    }
+    return res.json()
+  }
+
   function isAutenticato() {
     return !!getToken()
   }
@@ -125,5 +139,5 @@ export function useApi() {
     localStorage.setItem('github_token', token)
   }
 
-  return { saveJSON, uploadFile, isAutenticato, salvaToken }
+  return { saveJSON, uploadFile, deleteFile, isAutenticato, salvaToken }
 }

--- a/src/composables/useGalleria.js
+++ b/src/composables/useGalleria.js
@@ -1,0 +1,182 @@
+// Logica condivisa per la galleria foto (GalleryView.vue e PiantaView.vue):
+// lettura/eliminazione dei file su GitHub, generazione di thumbnail via
+// canvas al momento del caricamento, e mappa delle thumbnail per l'elenco
+// piante (una sola chiamata alla Git Trees API invece di una per pianta).
+import { useApi } from '@/composables/useApi'
+
+const OWNER  = 'ziabetta84'
+const REPO   = 'giardino'
+const BRANCH = 'main'
+const FOLDER = 'docs/gallery/piante'
+
+function apiHeaders() {
+  const token = localStorage.getItem('github_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+function rawUrl(path) {
+  return `https://raw.githubusercontent.com/${OWNER}/${REPO}/${BRANCH}/${path}`
+}
+
+function parseData(nome) {
+  const ts = parseInt(nome.split('_')[0])
+  if (!ts || isNaN(ts)) return null
+  return new Date(ts)
+}
+
+function formatBreve(d) {
+  if (!d) return ''
+  return d.toLocaleDateString('it-IT', { day: 'numeric', month: 'short', year: '2-digit' })
+}
+
+function formatEstesa(d) {
+  if (!d) return ''
+  return d.toLocaleDateString('it-IT', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })
+}
+
+const RE_THUMB = /_thumb\.(jpe?g|png|webp)$/i
+const RE_IMG   = /\.(jpe?g|png|gif|webp)$/i
+
+async function listDir(path) {
+  const res = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/contents/${path}`, { headers: apiHeaders() })
+  if (res.status === 404) return []
+  if (!res.ok) throw new Error(`Errore API GitHub: ${res.status}`)
+  return res.json()
+}
+
+export function useGalleria() {
+  const { uploadFile, deleteFile } = useApi()
+
+  // Foto di una singola cartella pianta (esclude le thumbnail: sono un
+  // dettaglio interno per l'elenco piante, non fanno parte della galleria).
+  async function listaFoto(cartella) {
+    const files = await listDir(`${FOLDER}/${cartella}`)
+    return files
+      .filter(f => f.type === 'file' && RE_IMG.test(f.name) && !RE_THUMB.test(f.name))
+      .map(f => {
+        const d = parseData(f.name)
+        return {
+          path: f.path,
+          nome: f.name,
+          sha:  f.sha,
+          cartella,
+          url:        rawUrl(f.path),
+          dataBreve:  formatBreve(d),
+          dataEstesa: formatEstesa(d),
+        }
+      })
+      .sort((a, b) => b.nome.localeCompare(a.nome))
+  }
+
+  // Tutte le cartelle pianta con relative foto (per la Galleria completa).
+  async function listaTutte() {
+    const cartelle = (await listDir(FOLDER)).filter(f => f.type === 'dir')
+    const risultati = await Promise.all(cartelle.map(c => listaFoto(c.name)))
+    return risultati.flat()
+  }
+
+  function elimina(foto) {
+    return deleteFile(foto.path, foto.sha, `Elimina foto ${foto.nome}`)
+  }
+
+  // Cancellazione best-effort di tutte le foto di una pianta (chiamata prima
+  // di rimuovere la pianta stessa): se la cartella non esiste non c'è nulla
+  // da fare; se una singola eliminazione fallisce non blocca le altre né la
+  // cancellazione della pianta, che è l'azione principale richiesta
+  // dall'utente — restare con qualche file orfano è preferibile a impedire
+  // di eliminare la pianta per un problema sulle foto.
+  async function eliminaCartella(cartella) {
+    let files
+    try {
+      files = await listDir(`${FOLDER}/${cartella}`)
+    } catch {
+      return
+    }
+    await Promise.all(
+      files
+        .filter(f => f.type === 'file')
+        .map(f => deleteFile(f.path, f.sha, `Elimina foto ${f.name}`).catch(() => {}))
+    )
+  }
+
+  // Ridimensiona un'immagine via canvas (lato client, nessun servizio
+  // esterno): usata per generare una thumbnail leggera da mostrare
+  // nell'elenco piante invece del file originale a piena risoluzione.
+  function ridimensiona(dataUrl, maxDim = 400, qualita = 0.8) {
+    return new Promise((resolve, reject) => {
+      const img = new Image()
+      img.onload = () => {
+        let { width, height } = img
+        if (width > height && width > maxDim) {
+          height = Math.round(height * maxDim / width)
+          width = maxDim
+        } else if (height > maxDim) {
+          width = Math.round(width * maxDim / height)
+          height = maxDim
+        }
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        canvas.getContext('2d').drawImage(img, 0, 0, width, height)
+        resolve(canvas.toDataURL('image/jpeg', qualita).split(',')[1])
+      }
+      img.onerror = () => reject(new Error('Impossibile leggere l\'immagine per la thumbnail'))
+      img.src = dataUrl
+    })
+  }
+
+  // Carica la foto originale e, se associata a una pianta, anche una
+  // thumbnail ridotta accanto ad essa (stesso prefisso timestamp, suffisso
+  // "_thumb"): mappaThumbnail() la userà per l'elenco piante. Il fallimento
+  // della sola generazione/upload della thumbnail non blocca il
+  // caricamento della foto originale, che resta l'obiettivo primario.
+  async function carica(cartella, dataUrl, base64) {
+    const ts   = Date.now()
+    const nome = `${ts}_upload.jpg`
+    const path = `${FOLDER}/${cartella}/${nome}`
+    await uploadFile(path, base64, `Aggiunge foto ${nome}`)
+
+    if (cartella && cartella !== 'generale') {
+      try {
+        const thumbBase64 = await ridimensiona(dataUrl)
+        const thumbNome = `${ts}_thumb.jpg`
+        await uploadFile(`${FOLDER}/${cartella}/${thumbNome}`, thumbBase64, `Aggiunge thumbnail ${thumbNome}`)
+      } catch {
+        // Vedi commento sopra: la foto originale è già stata caricata con successo.
+      }
+    }
+
+    const d = new Date(ts)
+    return { path, nome, cartella, url: rawUrl(path), dataBreve: formatBreve(d), dataEstesa: formatEstesa(d) }
+  }
+
+  // Una chiamata sola alla Git Trees API (ricorsiva) invece di una richiesta
+  // di elenco per ciascuna pianta: essenziale per non appesantire la vista
+  // Piante con decine di chiamate di rete solo per sapere quali hanno una
+  // thumbnail disponibile.
+  async function mappaThumbnail() {
+    const res = await fetch(
+      `https://api.github.com/repos/${OWNER}/${REPO}/git/trees/${BRANCH}?recursive=1`,
+      { headers: apiHeaders() }
+    )
+    if (!res.ok) throw new Error(`Errore API GitHub: ${res.status}`)
+    const { tree } = await res.json()
+
+    const mappa = {}
+    for (const voce of tree) {
+      if (voce.type !== 'blob') continue
+      if (!voce.path.startsWith(`${FOLDER}/`)) continue
+      const resto = voce.path.slice(FOLDER.length + 1)
+      const [cartella, nomeFile] = resto.split('/')
+      if (!nomeFile || !RE_THUMB.test(nomeFile)) continue
+      // Più thumbnail nella stessa cartella (foto multiple nel tempo): tiene
+      // la più recente confrontando il prefisso timestamp nel nome file.
+      if (!mappa[cartella] || nomeFile > mappa[cartella].nome) {
+        mappa[cartella] = { nome: nomeFile, url: rawUrl(voce.path) }
+      }
+    }
+    return Object.fromEntries(Object.entries(mappa).map(([cartella, v]) => [cartella, v.url]))
+  }
+
+  return { listaFoto, listaTutte, elimina, eliminaCartella, ridimensiona, carica, mappaThumbnail, rawUrl }
+}

--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -61,37 +61,26 @@
     </template>
 
     <!-- Lightbox -->
-    <Teleport to="body">
-      <div v-if="luce" @click.self="luce = null"
-        style="position:fixed;inset:0;z-index:300;background:rgba(0,0,0,0.94);display:flex;flex-direction:column;align-items:center;justify-content:center;">
+    <LightboxFoto
+      :foto="luce?.foto ?? null"
+      :titolo="luce?.gruppo?.nomeSpecie ?? ''"
+      :ha-precedente="indiceLuce > 0"
+      :ha-successivo="indiceLuce < tutteLeImmagini.length - 1"
+      :indice="indiceLuce"
+      :totale="tutteLeImmagini.length"
+      @chiudi="luce = null"
+      @naviga="navigaLuce"
+      @elimina="daEliminareFoto = luce.foto"
+    />
 
-        <!-- Info pianta in alto -->
-        <div style="position:absolute;top:0;left:0;right:0;padding:14px 16px;display:flex;align-items:center;gap:10px;">
-          <RouterLink :to="`/piante/${luce.gruppo.piantaId}`" @click="luce = null"
-            style="font-size:13px;font-weight:600;color:rgba(255,255,255,0.9);text-decoration:none;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
-            {{ luce.gruppo.nomeSpecie }}
-          </RouterLink>
-          <span style="font-size:11px;color:rgba(255,255,255,0.5);">{{ luce.foto.dataEstesa }}</span>
-          <button @click="luce = null"
-            style="background:rgba(255,255,255,0.12);border:none;border-radius:50%;width:32px;height:32px;color:white;font-size:18px;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;">×</button>
-        </div>
-
-        <!-- Immagine -->
-        <img :src="luce.foto.url" :alt="luce.foto.nome"
-          style="max-width:100%;max-height:calc(100vh - 100px);object-fit:contain;border-radius:8px;padding:56px 8px 44px;">
-
-        <!-- Navigazione prev/next -->
-        <button v-if="indiceLuce > 0" @click="navigaLuce(-1)"
-          style="position:absolute;left:8px;top:50%;transform:translateY(-50%);background:rgba(255,255,255,0.12);border:none;border-radius:50%;width:40px;height:40px;color:white;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;">‹</button>
-        <button v-if="indiceLuce < tutteLeImmagini.length - 1" @click="navigaLuce(1)"
-          style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:rgba(255,255,255,0.12);border:none;border-radius:50%;width:40px;height:40px;color:white;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;">›</button>
-
-        <!-- Contatore -->
-        <div style="position:absolute;bottom:14px;left:0;right:0;text-align:center;">
-          <span style="font-size:11px;color:rgba(255,255,255,0.4);">{{ indiceLuce + 1 }} / {{ tutteLeImmagini.length }}</span>
-        </div>
-      </div>
-    </Teleport>
+    <ModalConferma
+      :aperto="!!daEliminareFoto"
+      titolo="Eliminare questa foto?"
+      messaggio="Questa azione non può essere annullata."
+      :caricamento="eliminandoFoto"
+      @conferma="confermaEliminaFoto"
+      @annulla="daEliminareFoto = null"
+    />
 
     <!-- Modal upload -->
     <Teleport to="body">
@@ -139,10 +128,12 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useDatiStore } from '@/stores/dati'
-import { useApi } from '@/composables/useApi'
+import { useGalleria } from '@/composables/useGalleria'
+import LightboxFoto from '@/components/LightboxFoto.vue'
+import ModalConferma from '@/components/ModalConferma.vue'
 
 const store = useDatiStore()
-const { uploadFile } = useApi()
+const galleria = useGalleria()
 
 const foto            = ref([])
 const caricandoLista  = ref(false)
@@ -150,42 +141,13 @@ const caricandoUpload = ref(false)
 const errore          = ref(null)
 const erroreUpload    = ref(null)
 const luce            = ref(null)   // { foto, gruppo }
+const daEliminareFoto = ref(null)
+const eliminandoFoto  = ref(false)
 const mostraFormUpload = ref(false)
 const uploadPiantaId  = ref('')
 const uploadFile64    = ref(null)
+const uploadDataUrl   = ref(null)
 const uploadPreview   = ref(null)
-
-const OWNER  = 'ziabetta84'
-const REPO   = 'giardino'
-const BRANCH = 'main'
-const FOLDER = 'docs/gallery/piante'
-
-function rawUrl(path) {
-  return `https://raw.githubusercontent.com/${OWNER}/${REPO}/${BRANCH}/${path}`
-}
-function apiHeaders() {
-  const token = localStorage.getItem('github_token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
-async function listDir(path) {
-  const res = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/contents/${path}`, { headers: apiHeaders() })
-  if (res.status === 404) return []
-  if (!res.ok) throw new Error(`Errore API GitHub: ${res.status}`)
-  return res.json()
-}
-function parseData(nome) {
-  const ts = parseInt(nome.split('_')[0])
-  if (!ts || isNaN(ts)) return null
-  return new Date(ts)
-}
-function formatBreve(d) {
-  if (!d) return ''
-  return d.toLocaleDateString('it-IT', { day: 'numeric', month: 'short', year: '2-digit' })
-}
-function formatEstesa(d) {
-  if (!d) return ''
-  return d.toLocaleDateString('it-IT', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })
-}
 
 // Piante raggruppate per zona (per il select dell'upload)
 const piantaPerZona = computed(() => {
@@ -235,6 +197,19 @@ function navigaLuce(dir) {
   }
 }
 
+async function confermaEliminaFoto() {
+  if (!daEliminareFoto.value) return
+  eliminandoFoto.value = true
+  try {
+    await galleria.elimina(daEliminareFoto.value)
+    foto.value = foto.value.filter(f => f.path !== daEliminareFoto.value.path)
+    if (luce.value?.foto.path === daEliminareFoto.value.path) luce.value = null
+    daEliminareFoto.value = null
+  } finally {
+    eliminandoFoto.value = false
+  }
+}
+
 // Tastiera per lightbox
 function onKey(e) {
   if (!luce.value) return
@@ -249,29 +224,7 @@ onMounted(async () => {
   caricandoLista.value = true
   errore.value = null
   try {
-    const cartelle = await listDir(FOLDER)
-    const tutte = []
-    await Promise.all(
-      cartelle
-        .filter(f => f.type === 'dir')
-        .map(async cartella => {
-          const files = await listDir(cartella.path)
-          files
-            .filter(f => f.type === 'file' && /\.(jpe?g|png|gif|webp)$/i.test(f.name))
-            .forEach(f => {
-              const d = parseData(f.name)
-              tutte.push({
-                path:      f.path,
-                nome:      f.name,
-                cartella:  cartella.name,
-                url:       rawUrl(f.path),
-                dataBreve: formatBreve(d),
-                dataEstesa: formatEstesa(d),
-              })
-            })
-        })
-    )
-    foto.value = tutte
+    foto.value = await galleria.listaTutte()
   } catch (e) {
     errore.value = e.message
   } finally {
@@ -285,6 +238,7 @@ function selezionaUpload(e) {
   const reader = new FileReader()
   reader.onload = () => {
     uploadPreview.value = reader.result
+    uploadDataUrl.value = reader.result
     uploadFile64.value  = reader.result.split(',')[1]
   }
   reader.readAsDataURL(file)
@@ -295,20 +249,12 @@ async function caricaFoto() {
   caricandoUpload.value = true
   erroreUpload.value = null
   try {
-    const ts     = Date.now()
     const cartella = uploadPiantaId.value || 'generale'
-    const nome   = `${ts}_upload.jpg`
-    const path   = `${FOLDER}/${cartella}/${nome}`
-    await uploadFile(path, uploadFile64.value, `Aggiunge foto ${nome}`)
-    const d = new Date(ts)
-    foto.value.unshift({
-      path, nome, cartella,
-      url:       rawUrl(path),
-      dataBreve: formatBreve(d),
-      dataEstesa: formatEstesa(d),
-    })
+    const nuovaFoto = await galleria.carica(cartella, uploadDataUrl.value, uploadFile64.value)
+    foto.value.unshift(nuovaFoto)
     mostraFormUpload.value = false
     uploadFile64.value  = null
+    uploadDataUrl.value = null
     uploadPreview.value = null
     uploadPiantaId.value = ''
   } catch (e) {

--- a/src/views/PiantaView.vue
+++ b/src/views/PiantaView.vue
@@ -105,6 +105,21 @@
         <p style="font-size:13px;color:var(--ink-mid);line-height:1.6;">{{ pianta.note }}</p>
       </div>
 
+      <!-- Foto -->
+      <div v-if="caricandoFoto || fotoPianta.length" class="card" style="padding:16px;margin-bottom:12px;">
+        <p class="section-label" style="margin-bottom:10px;">Foto</p>
+        <div v-if="caricandoFoto" style="display:flex;gap:8px;">
+          <div v-for="i in 3" :key="i" class="skeleton" style="width:72px;height:72px;border-radius:12px;flex-shrink:0;"></div>
+        </div>
+        <div v-else style="display:flex;gap:8px;overflow-x:auto;padding-bottom:4px;">
+          <div v-for="f in fotoPianta" :key="f.path"
+            @click="luce = f"
+            style="width:72px;height:72px;border-radius:12px;overflow:hidden;cursor:pointer;background:var(--cream-dark);flex-shrink:0;">
+            <img :src="f.url" :alt="f.nome" style="width:100%;height:100%;object-fit:cover;" loading="lazy">
+          </div>
+        </div>
+      </div>
+
       <!-- Info impianto -->
       <div v-if="pianta.impianto" class="card" style="padding:14px 16px;margin-bottom:12px;">
         <p style="font-size:12px;color:var(--ink-soft);">Messa a dimora: <strong>{{ pianta.impianto }}</strong></p>
@@ -121,31 +136,99 @@
     <ModalConferma
       :aperto="daEliminare"
       titolo="Eliminare questa pianta?"
-      messaggio="Questa azione non può essere annullata."
+      :messaggio="messaggioEliminaPianta"
       :caricamento="eliminando"
       @conferma="eliminaPianta"
       @annulla="daEliminare = false"
+    />
+
+    <LightboxFoto
+      :foto="luce"
+      :titolo="specie?.nome ?? pianta?.specie ?? ''"
+      :ha-precedente="indiceLuce > 0"
+      :ha-successivo="indiceLuce < fotoPianta.length - 1"
+      :indice="indiceLuce"
+      :totale="fotoPianta.length"
+      @chiudi="luce = null"
+      @naviga="dir => { luce = fotoPianta[indiceLuce + dir] }"
+      @elimina="daEliminareFoto = luce"
+    />
+
+    <ModalConferma
+      :aperto="!!daEliminareFoto"
+      titolo="Eliminare questa foto?"
+      messaggio="Questa azione non può essere annullata."
+      :caricamento="eliminandoFoto"
+      @conferma="confermaEliminaFoto"
+      @annulla="daEliminareFoto = null"
     />
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useDatiStore } from '@/stores/dati'
 import { useApi } from '@/composables/useApi'
+import { useGalleria } from '@/composables/useGalleria'
 import { valutaCura, cureUrgentiPianta, stagione } from '@/composables/useCure'
 import { concimeConsigliato } from '@/composables/useConcimi'
 import ModalConferma from '@/components/ModalConferma.vue'
+import LightboxFoto from '@/components/LightboxFoto.vue'
 
 const route  = useRoute()
 const router = useRouter()
 const store  = useDatiStore()
 const { saveJSON } = useApi()
+const galleria = useGalleria()
 
 const salvando   = ref(null)
 const daEliminare = ref(false)
 const eliminando  = ref(false)
+
+const fotoPianta    = ref([])
+const caricandoFoto = ref(false)
+const luce          = ref(null)
+const daEliminareFoto = ref(null)
+const eliminandoFoto  = ref(false)
+
+const indiceLuce = computed(() => luce.value ? fotoPianta.value.findIndex(f => f.path === luce.value.path) : -1)
+
+const messaggioEliminaPianta = computed(() => {
+  const n = fotoPianta.value.length
+  if (!n) return 'Questa azione non può essere annullata.'
+  return n === 1
+    ? 'Questa azione non può essere annullata. Verrà eliminata anche la foto associata.'
+    : `Questa azione non può essere annullata. Verranno eliminate anche le ${n} foto associate.`
+})
+
+async function caricaFotoPianta(id) {
+  if (!id) { fotoPianta.value = []; return }
+  caricandoFoto.value = true
+  try {
+    fotoPianta.value = await galleria.listaFoto(id)
+  } catch {
+    fotoPianta.value = []
+  } finally {
+    caricandoFoto.value = false
+  }
+}
+
+onMounted(() => caricaFotoPianta(route.params.id))
+watch(() => route.params.id, (id) => caricaFotoPianta(id))
+
+async function confermaEliminaFoto() {
+  if (!daEliminareFoto.value) return
+  eliminandoFoto.value = true
+  try {
+    await galleria.elimina(daEliminareFoto.value)
+    fotoPianta.value = fotoPianta.value.filter(f => f.path !== daEliminareFoto.value.path)
+    if (luce.value?.path === daEliminareFoto.value.path) luce.value = null
+    daEliminareFoto.value = null
+  } finally {
+    eliminandoFoto.value = false
+  }
+}
 
 const pianta = computed(() => {
   if (!store.piante) return null
@@ -199,6 +282,7 @@ async function eliminaPianta() {
   eliminando.value = true
   const id = pianta.value.id
   try {
+    await galleria.eliminaCartella(id)
     const nuove = await saveJSON('piante.json', (correnti) => {
       const base = { ...(correnti ?? store.piante) }
       delete base[id]

--- a/src/views/PianteView.vue
+++ b/src/views/PianteView.vue
@@ -48,7 +48,7 @@
       <template v-if="!cerca && filtroZona === 'tutte' && pianteUrgenti.length">
         <p class="section-label">⚠ Da curare</p>
         <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:20px;">
-          <PiantaRiga v-for="p in pianteUrgenti" :key="'u'+p.id" :pianta="p" urgente
+          <PiantaRiga v-for="p in pianteUrgenti" :key="'u'+p.id" :pianta="p" urgente :thumb-url="thumbnail[p.id]"
             @elimina="avviaElimina(p)" />
         </div>
         <p class="section-label">Tutte le piante</p>
@@ -56,7 +56,7 @@
 
       <!-- Lista principale -->
       <div v-if="pianteFiltrate.length" style="display:flex;flex-direction:column;gap:8px;">
-        <PiantaRiga v-for="p in pianteFiltrate" :key="p.id" :pianta="p"
+        <PiantaRiga v-for="p in pianteFiltrate" :key="p.id" :pianta="p" :thumb-url="thumbnail[p.id]"
           @elimina="avviaElimina(p)" />
       </div>
 
@@ -71,7 +71,7 @@
     <ModalConferma
       :aperto="!!daEliminare"
       titolo="Eliminare questa pianta?"
-      messaggio="Questa azione non può essere annullata."
+      messaggio="Questa azione non può essere annullata. Verranno eliminate anche eventuali foto associate."
       :caricamento="eliminando"
       @conferma="eliminaPianta"
       @annulla="daEliminare = null"
@@ -80,10 +80,11 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useDatiStore } from '@/stores/dati'
 import { useApi } from '@/composables/useApi'
+import { useGalleria } from '@/composables/useGalleria'
 import { cureUrgentiPianta } from '@/composables/useCure'
 import ModalConferma from '@/components/ModalConferma.vue'
 import PiantaRiga from '@/components/PiantaRiga.vue'
@@ -91,6 +92,19 @@ import PiantaRiga from '@/components/PiantaRiga.vue'
 const store      = useDatiStore()
 const route      = useRoute()
 const { saveJSON } = useApi()
+const galleria   = useGalleria()
+
+// Una sola chiamata per tutte le piante (vedi useGalleria.mappaThumbnail):
+// se fallisce (rete assente, repo privata senza token, ecc.) l'elenco resta
+// comunque utilizzabile, semplicemente senza le miniature.
+const thumbnail = ref({})
+onMounted(async () => {
+  try {
+    thumbnail.value = await galleria.mappaThumbnail()
+  } catch {
+    thumbnail.value = {}
+  }
+})
 
 const cerca      = ref('')
 const filtroZona = ref(route.query.zona ?? 'tutte')
@@ -163,6 +177,7 @@ async function eliminaPianta() {
   eliminando.value = true
   const id = daEliminare.value.id
   try {
+    await galleria.eliminaCartella(id)
     const nuove = await saveJSON('piante.json', (correnti) => {
       const base = { ...(correnti ?? store.piante) }
       delete base[id]


### PR DESCRIPTION
## Summary
Risponde ai 4 punti discussi sulla Gallery:

- **Eliminazione foto**: aggiunge `deleteFile()` a `useApi.js` (DELETE Contents API); nuovo lightbox condiviso `LightboxFoto.vue` con bottone elimina, usato sia in `GalleryView` che nella nuova sezione foto di `PiantaView`
- **Foto nella scheda pianta**: `PiantaView` mostra ora una striscia scorrevole delle foto della pianta, con lightbox e possibilità di eliminarle
- **Thumbnail nell'elenco piante, con resize reale**: al caricamento di una foto associata a una pianta, `useGalleria.carica()` genera anche una thumbnail via canvas (max 400px, JPEG 0.8) e la carica accanto all'originale; `PianteView` recupera la mappa `{piantaId: url}` delle thumbnail con **una sola chiamata** alla Git Trees API (non una per pianta) e la passa a `PiantaRiga`, che mostra l'immagine ridotta al posto dell'emoji quando presente
- **Cancellazione a cascata**: eliminando una pianta (dall'elenco o dalla scheda) vengono cancellate anche le sue foto su GitHub; la conferma segnala quante foto verranno rimosse (singolare/plurale corretto)

Estrae la logica di lettura foto in `useGalleria.js`, condivisa tra `GalleryView.vue` (che prima la duplicava inline) e `PiantaView.vue`.

Corregge anche lo z-index di `ModalConferma.vue` (200 → 400): scoperto testando il nuovo flusso, la conferma di eliminazione foto restava coperta e non cliccabile dietro il lightbox (z-index 300).

## Test plan
- [x] `npm run build` completato senza errori
- [x] Test Playwright end-to-end con fixture controllate (dati locali + Contents API + Git Trees API mockati, stateful sulle DELETE):
  - Galleria: 2 foto mostrate (thumbnail esclusa dalla vista), eliminazione di una foto funzionante con richiesta DELETE corretta (path + sha)
  - Scheda pianta: stessa foto residua mostrata, lightbox condiviso apribile anche da qui
  - Elenco piante: thumbnail mostrata solo per la pianta che ne ha una disponibile
  - Eliminazione pianta: messaggio di conferma corretto (singolare), cascade delete che rimuove tutti i file residui (foto + thumbnail) della cartella
- [x] Individuato e corretto un bug reale di z-index durante il test (non solo un artefatto del test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_