### PR TITLE
Aggiunge "calcio" come quarta cura tracciata (guscio d'uovo)

### DIFF
--- a/src/components/AttivitaRiga.vue
+++ b/src/components/AttivitaRiga.vue
@@ -28,8 +28,9 @@ const props = defineProps({
 })
 defineEmits(['registra'])
 
+const ICONE = { irrigazione: '💧', concimazione: '🌱', potatura: '✂️', calcio: '🥚' }
 function icona(tipo) {
-  return tipo === 'irrigazione' ? '💧' : tipo === 'concimazione' ? '🌱' : '✂️'
+  return ICONE[tipo] ?? '🌿'
 }
 
 const cardStyle = computed(() => {

--- a/src/components/SelettoreSpecie.vue
+++ b/src/components/SelettoreSpecie.vue
@@ -72,7 +72,14 @@
             <input v-model="nuovaSpecie.manutenzione.npk.estate" placeholder="N-P-K">
             <input v-model="nuovaSpecie.manutenzione.npk.autunno" placeholder="N-P-K">
             <input v-model="nuovaSpecie.manutenzione.npk.inverno" placeholder="N-P-K">
+
+            <div class="tipo-label">🥚 Calcio</div>
+            <input type="number" min="1" v-model.number="nuovaSpecie.manutenzione.calcio.primavera" placeholder="gg">
+            <input type="number" min="1" v-model.number="nuovaSpecie.manutenzione.calcio.estate" placeholder="gg">
+            <input type="number" min="1" v-model.number="nuovaSpecie.manutenzione.calcio.autunno" placeholder="gg">
+            <input type="number" min="1" v-model.number="nuovaSpecie.manutenzione.calcio.inverno" placeholder="gg">
           </div>
+          <p style="font-size:11px;color:var(--ink-faint);margin:6px 0 0;">Calcio: da riempire solo per specie con beneficio documentato (es. marciume apicale su solanacee/cucurbitacee) — lascia vuoto per tutte le altre.</p>
 
           <label style="font-size:11px;font-weight:600;color:var(--ink-soft);text-transform:uppercase;letter-spacing:.05em;display:block;margin:12px 0 2px;">✂️ Potatura (opzionale)</label>
           <p style="font-size:11px;color:var(--ink-faint);margin:0 0 8px;">Non è a cadenza fissa come le altre: testo libero per stagione, es. "taglio leggero", "post-fioritura", "nessuna".</p>
@@ -162,7 +169,7 @@ const STAGIONI = ['primavera', 'estate', 'autunno', 'inverno']
 
 function manutenzioneVuota() {
   const perStagione = () => ({ primavera: '', estate: '', autunno: '', inverno: '' })
-  return { irrigazione: perStagione(), concimazione: perStagione(), potatura: perStagione(), npk: perStagione() }
+  return { irrigazione: perStagione(), concimazione: perStagione(), potatura: perStagione(), npk: perStagione(), calcio: perStagione() }
 }
 
 // Per irrigazione/concimazione il campo del form è solo numerico ("ogni N
@@ -175,6 +182,7 @@ function manutenzioneVuota() {
 const manutenzioneOriginale = ref({
   irrigazione: { primavera: '', estate: '', autunno: '', inverno: '' },
   concimazione: { primavera: '', estate: '', autunno: '', inverno: '' },
+  calcio: { primavera: '', estate: '', autunno: '', inverno: '' },
 })
 
 function estraiGiorniPuliti(testo) {
@@ -198,7 +206,7 @@ const nuovaSpecie = ref({ nome: '', nomeScientifico: '', descrizione: '', luce: 
 // libero invece di essere convertita da un numero di giorni.
 function generaManutenzione(struttura, originale) {
   const risultato = {}
-  for (const tipo of ['irrigazione', 'concimazione']) {
+  for (const tipo of ['irrigazione', 'concimazione', 'calcio']) {
     risultato[tipo] = {}
     for (const stagione of STAGIONI) {
       const giorni = struttura?.[tipo]?.[stagione]
@@ -229,7 +237,11 @@ function slug(testo) {
 
 function apriNuovaSpecie() {
   nuovaSpecie.value = { nome: specieQuery.value.trim(), nomeScientifico: '', descrizione: '', luce: '', acqua: '', terreno: '', alert: '', manutenzione: manutenzioneVuota() }
-  manutenzioneOriginale.value = { irrigazione: { primavera: '', estate: '', autunno: '', inverno: '' }, concimazione: { primavera: '', estate: '', autunno: '', inverno: '' } }
+  manutenzioneOriginale.value = {
+    irrigazione: { primavera: '', estate: '', autunno: '', inverno: '' },
+    concimazione: { primavera: '', estate: '', autunno: '', inverno: '' },
+    calcio: { primavera: '', estate: '', autunno: '', inverno: '' },
+  }
   specieModificaOriginale.value = null
   erroreSpecie.value = null
   dropdownAperto.value = false
@@ -241,8 +253,12 @@ function apriModificaSpecie(s) {
   if (!record) return
 
   const manutenzione = manutenzioneVuota()
-  const originale = { irrigazione: { primavera: '', estate: '', autunno: '', inverno: '' }, concimazione: { primavera: '', estate: '', autunno: '', inverno: '' } }
-  for (const tipo of ['irrigazione', 'concimazione']) {
+  const originale = {
+    irrigazione: { primavera: '', estate: '', autunno: '', inverno: '' },
+    concimazione: { primavera: '', estate: '', autunno: '', inverno: '' },
+    calcio: { primavera: '', estate: '', autunno: '', inverno: '' },
+  }
+  for (const tipo of ['irrigazione', 'concimazione', 'calcio']) {
     for (const stagione of STAGIONI) {
       const testo = record.manutenzione?.[tipo]?.[stagione] || ''
       const numero = estraiGiorniPuliti(testo)

--- a/src/composables/useCure.js
+++ b/src/composables/useCure.js
@@ -64,7 +64,7 @@ export function valutaCura(pianta, specie, tipo, contesto = {}) {
 }
 
 export function cureUrgentiPianta(pianta, specie, contesto) {
-  return ['irrigazione','concimazione','potatura']
+  return ['irrigazione','concimazione','potatura','calcio']
     .map(tipo => ({ tipo, ...valutaCura(pianta, specie, tipo, contesto) }))
     .filter(c => c.urgente)
 }

--- a/src/views/AttivitaView.vue
+++ b/src/views/AttivitaView.vue
@@ -85,7 +85,7 @@ const attivita = computed(() => {
     const sp = store.specie?.[p.specie] ?? null
     const nomeSpecie = sp?.nome ?? p.specie
     const contesto = { ...contestoMeteo, esterno: store.zone?.[p.zona]?.tipo === 'esterno' }
-    for (const tipo of ['irrigazione', 'concimazione', 'potatura']) {
+    for (const tipo of ['irrigazione', 'concimazione', 'potatura', 'calcio']) {
       const c = valutaCura(p, sp, tipo, contesto)
       if (c.giorni !== null) {
         const suggerimento = tipo === 'concimazione'

--- a/src/views/PiantaView.vue
+++ b/src/views/PiantaView.vue
@@ -57,7 +57,7 @@
       <div class="card" style="padding:16px;margin-bottom:12px;">
         <p class="section-label" style="margin-bottom:10px;">Stato cure</p>
         <div style="display:flex;flex-direction:column;gap:10px;">
-          <div v-for="tipo in ['irrigazione','concimazione','potatura']" :key="tipo"
+          <div v-for="tipo in tipiCura" :key="tipo"
             style="display:flex;align-items:center;justify-content:space-between;">
             <div>
               <div style="font-size:13px;font-weight:500;text-transform:capitalize;">{{ tipo }}</div>
@@ -244,6 +244,16 @@ const contestoCura = computed(() => ({
   esterno: store.zone?.[pianta.value?.zona]?.tipo === 'esterno',
   meteo: store.meteo,
 }))
+
+// "calcio" riguarda solo le poche specie con un beneficio documentato (vedi
+// specie.json): mostrarlo comunque per tutte le altre come "Non configurata"
+// sarebbe rumore, a differenza di irrigazione/concimazione/potatura che sono
+// pertinenti ovunque.
+const tipiCura = computed(() => {
+  const base = ['irrigazione', 'concimazione', 'potatura']
+  if (specie.value?.manutenzione?.calcio) base.push('calcio')
+  return base
+})
 
 const cureUrgenti = computed(() =>
   pianta.value ? cureUrgentiPianta(pianta.value, specie.value, contestoCura.value) : []


### PR DESCRIPTION
## Summary
Segue la discussione in chat su gusci d'uovo/calcio: aggiunge "calcio" come quarta cura tracciata dal motore esistente (irrigazione/concimazione/potatura), scoped alle 6 specie a beneficio documentato (i dati in `specie.json` — pomodoro, melanzana, peperoncino, zucchina, zucca, cetriolo — sono già stati aggiunti in un commit dati precedente).

- `useCure.js`: `cureUrgentiPianta` valuta ora anche `'calcio'` (`valutaCura` era già generico sul tipo, nessuna modifica necessaria lì)
- `PiantaView.vue`: la riga "Calcio" in "Stato cure" compare solo se la specie ha effettivamente `manutenzione.calcio` definita — altrimenti sarebbe "Non configurata" su ~94 specie per cui non ha senso
- `AttivitaView.vue`: aggiunge `'calcio'` alla lista dei tipi valutati; il filtro esistente su `giorni !== null` esclude già automaticamente le piante non pertinenti
- `AttivitaRiga.vue`: la mappatura icone era un ternario a due rami che faceva ricadere qualunque tipo sconosciuto sulle forbici (potatura) — bug trovato durante l'implementazione, corretto con una mappa esplicita + icona dedicata 🥚 per calcio
- `SelettoreSpecie.vue`: aggiunge la riga "Calcio" alla griglia manutenzione del form (stesso pattern "ogni N giorni" di irrigazione/concimazione), modificabile anche per specie future

## Test plan
- [x] `npm run build` completato senza errori
- [x] Test Playwright con fixture (pomodoro con calcio scaduto, sedum senza calcio):
  - Scheda pianta: pomodoro mostra "calcio — mai registrata" tra le urgenze; sedum non mostra affatto la riga calcio
  - Attività: pomodoro compare tra le urgenze con icona 🥚 (non più le forbici)
  - Form specie: la riga "Calcio" compare e precompila correttamente il valore (21 giorni → "ogni 21 giorni")


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_