### PR TITLE
Legge la data EXIF al caricamento delle foto nella Galleria

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "giardino",
       "version": "0.1.0",
       "dependencies": {
+        "exifr": "^7.1.3",
         "pinia": "^2.2.0",
         "vue": "^3.5.0",
         "vue-router": "^4.4.0"
@@ -3785,6 +3786,12 @@
       "funding": {
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "exifr": "^7.1.3",
     "pinia": "^2.2.0",
     "vue": "^3.5.0",
     "vue-router": "^4.4.0"

--- a/src/composables/useGalleria.js
+++ b/src/composables/useGalleria.js
@@ -3,6 +3,7 @@
 // canvas al momento del caricamento, e mappa delle thumbnail per l'elenco
 // piante (una sola chiamata alla Git Trees API invece di una per pianta).
 import { useApi } from '@/composables/useApi'
+import { parse as parseExif } from 'exifr/dist/lite.esm.mjs'
 
 const OWNER  = 'ziabetta84'
 const REPO   = 'giardino'
@@ -125,13 +126,32 @@ export function useGalleria() {
     })
   }
 
+  // Legge la data di scatto dai metadati EXIF del file (DateTimeOriginal),
+  // così una foto importata da un altro dispositivo/servizio (es. scaricata
+  // da Google Photos) viene datata con il momento in cui è stata scattata
+  // invece che con quello del caricamento nell'app. Restituisce null se il
+  // file non ha EXIF leggibili (comune per screenshot, immagini già
+  // rielaborate, o alcuni export che rimuovono i metadati) — non è quindi
+  // una garanzia, solo un recupero quando l'informazione è disponibile.
+  async function leggiDataScatto(file) {
+    try {
+      const exif = await parseExif(file)
+      return exif?.DateTimeOriginal instanceof Date ? exif.DateTimeOriginal : null
+    } catch {
+      return null
+    }
+  }
+
   // Carica la foto originale e, se associata a una pianta, anche una
   // thumbnail ridotta accanto ad essa (stesso prefisso timestamp, suffisso
   // "_thumb"): mappaThumbnail() la userà per l'elenco piante. Il fallimento
   // della sola generazione/upload della thumbnail non blocca il
   // caricamento della foto originale, che resta l'obiettivo primario.
-  async function carica(cartella, dataUrl, base64) {
-    const ts   = Date.now()
+  // dataScatto (opzionale): se nota (letta da leggiDataScatto), sostituisce
+  // il momento del caricamento come timestamp del file, così l'ordinamento
+  // e la data mostrata riflettono quando la foto è stata scattata.
+  async function carica(cartella, dataUrl, base64, dataScatto = null) {
+    const ts   = dataScatto instanceof Date ? dataScatto.getTime() : Date.now()
     const nome = `${ts}_upload.jpg`
     const path = `${FOLDER}/${cartella}/${nome}`
     await uploadFile(path, base64, `Aggiunge foto ${nome}`)
@@ -178,5 +198,5 @@ export function useGalleria() {
     return Object.fromEntries(Object.entries(mappa).map(([cartella, v]) => [cartella, v.url]))
   }
 
-  return { listaFoto, listaTutte, elimina, eliminaCartella, ridimensiona, carica, mappaThumbnail, rawUrl }
+  return { listaFoto, listaTutte, elimina, eliminaCartella, ridimensiona, carica, leggiDataScatto, mappaThumbnail, rawUrl }
 }

--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -111,6 +111,10 @@
             <input type="file" accept="image/*" capture="environment" @change="selezionaUpload" style="display:none;">
           </label>
 
+          <p v-if="dataScattoRilevata" style="font-size:11px;color:var(--sage-dark);margin-top:8px;">
+            📅 Data rilevata dai metadati: {{ dataScattoRilevata.toLocaleDateString('it-IT', { day:'numeric', month:'long', year:'numeric' }) }}
+          </p>
+
           <p v-if="erroreUpload" style="font-size:12px;color:var(--rose-dark);margin-top:8px;">⚠ {{ erroreUpload }}</p>
 
           <div style="display:flex;gap:10px;margin-top:16px;">
@@ -148,6 +152,7 @@ const uploadPiantaId  = ref('')
 const uploadFile64    = ref(null)
 const uploadDataUrl   = ref(null)
 const uploadPreview   = ref(null)
+const dataScattoRilevata = ref(null)
 
 // Piante raggruppate per zona (per il select dell'upload)
 const piantaPerZona = computed(() => {
@@ -235,6 +240,8 @@ onMounted(async () => {
 function selezionaUpload(e) {
   const file = e.target.files?.[0]
   if (!file) return
+  dataScattoRilevata.value = null
+  galleria.leggiDataScatto(file).then(d => { dataScattoRilevata.value = d })
   const reader = new FileReader()
   reader.onload = () => {
     uploadPreview.value = reader.result
@@ -250,13 +257,14 @@ async function caricaFoto() {
   erroreUpload.value = null
   try {
     const cartella = uploadPiantaId.value || 'generale'
-    const nuovaFoto = await galleria.carica(cartella, uploadDataUrl.value, uploadFile64.value)
+    const nuovaFoto = await galleria.carica(cartella, uploadDataUrl.value, uploadFile64.value, dataScattoRilevata.value)
     foto.value.unshift(nuovaFoto)
     mostraFormUpload.value = false
     uploadFile64.value  = null
     uploadDataUrl.value = null
     uploadPreview.value = null
     uploadPiantaId.value = ''
+    dataScattoRilevata.value = null
   } catch (e) {
     erroreUpload.value = e.message
   } finally {


### PR DESCRIPTION
## Summary
- Il nome file (che codifica la data mostrata dall'app) usava sempre il momento del caricamento, facendo apparire "di oggi" foto scattate mesi prima e caricate successivamente (es. scaricate da Google Photos)
- Aggiunge `useGalleria.leggiDataScatto(file)`, che legge il tag EXIF `DateTimeOriginal` (libreria `exifr`, build "lite") al momento della selezione del file nel form di upload della Galleria
- Se presente, la data rilevata sostituisce il timestamp di caricamento nel nome sia della foto che della thumbnail generata, ed è mostrata nell'anteprima prima di confermare ("📅 Data rilevata dai metadati: ...")
- Se il file non ha EXIF leggibili (screenshot, immagini rielaborate, alcuni export che li rimuovono), il comportamento resta quello di prima (timestamp di caricamento) — non è una garanzia, solo un recupero quando l'informazione è disponibile
- Corregge anche a mano la foto già caricata oggi (Margherita delle Canarie), rinominata con la data reale letta dai metadati sul computer dell'utente (4 maggio 2026, 18:43)

Nota tecnica: la build "mini" di `exifr` (la più leggera) restituisce solo tag numerici grezzi senza conversione a `Date` — serve la build "lite" (ancora molto più leggera della "full", che include anche XMP/IPTC/ICC/GPS non necessari qui) per ottenere `DateTimeOriginal` già come oggetto `Date`.

## Test plan
- [x] `npm run build` completato senza errori
- [x] Creato un JPEG di test con EXIF `DateTimeOriginal` valido (Python + piexif) e verificato con un piccolo script Node che `exifr` lo legge correttamente
- [x] Test Playwright end-to-end: selezionando il file di test nel form di upload, l'anteprima mostra la data rilevata correttamente; confermando il caricamento, sia la foto che la thumbnail vengono salvate con il timestamp EXIF invece di quello di caricamento


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_