### PR TITLE
Mostra la varietà nel menu pianta dell'upload foto in Galleria

### DIFF
--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -95,7 +95,7 @@
           <select v-model="uploadPiantaId" class="form-input" style="margin-bottom:14px;">
             <option value="">Nessuna (foto generica)</option>
             <optgroup v-for="(ps, zona) in piantaPerZona" :key="zona" :label="zona">
-              <option v-for="p in ps" :key="p.id" :value="p.id">{{ p.nomeSpecie }}</option>
+              <option v-for="p in ps" :key="p.id" :value="p.id">{{ p.etichetta }}</option>
             </optgroup>
           </select>
 
@@ -162,7 +162,8 @@ const piantaPerZona = computed(() => {
     const sp = store.specie?.[p.specie]
     const zona = p.zona ?? 'Altro'
     if (!gruppi[zona]) gruppi[zona] = []
-    gruppi[zona].push({ id, nomeSpecie: sp?.nome ?? p.specie })
+    const nomeSpecie = sp?.nome ?? p.specie
+    gruppi[zona].push({ id, nomeSpecie, etichetta: p.varieta ? `${nomeSpecie} — ${p.varieta}` : nomeSpecie })
   }
   return gruppi
 })


### PR DESCRIPTION
## Summary
- Il menu a tendina "Pianta" nel form di upload foto della Galleria mostrava solo il nome specie, rendendo difficile distinguere piante della stessa specie con varietà diverse
- Aggiunge la varietà all'etichetta con lo stesso pattern "Nome — Varietà" già usato in `PiantaView.vue`; se la pianta non ha una varietà impostata mostra solo il nome, invariato rispetto a prima

## Test plan
- [x] `npm run build` completato senza errori
- [x] Test Playwright: verificato che una pianta con varietà mostra "Pomodoro Test — Occhio di bue" e una senza mostra solo "Pomodoro Test"


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_