### PR TITLE
Fix thumbnail corrotta: canvas 2d non accelerato via GPU

### DIFF
--- a/src/composables/useGalleria.js
+++ b/src/composables/useGalleria.js
@@ -103,11 +103,13 @@ export function useGalleria() {
   // Ridimensiona un'immagine via canvas (lato client, nessun servizio
   // esterno): usata per generare una thumbnail leggera da mostrare
   // nell'elenco piante invece del file originale a piena risoluzione.
-  // Usa createImageBitmap con resize nativo del browser invece di un
-  // singolo drawImage in downscale: su alcuni motori di rendering un
-  // ridimensionamento manuale molto spinto (es. 4000px+ → 400px in un
-  // solo passaggio) produce un'immagine corrotta (artefatti a strisce),
-  // mentre il resize nativo in fase di decodifica è affidabile.
+  // Usa createImageBitmap con resize nativo del browser per il downscale
+  // (più affidabile di un singolo drawImage manuale su ridimensionamenti
+  // spinti), e willReadFrequently sul contesto 2d per forzare un canvas
+  // non accelerato via GPU: su alcuni dispositivi mobili (osservato con
+  // GPU Mali/MediaTek) il readback del canvas accelerato produce
+  // un'immagine corrotta (artefatti a strisce o a scacchiera) pur
+  // restando un JPEG valido a livello di contenitore.
   async function ridimensiona(file, maxDim = 400, qualita = 0.8) {
     const originale = await createImageBitmap(file)
     let { width, height } = originale
@@ -124,7 +126,7 @@ export function useGalleria() {
     const canvas = document.createElement('canvas')
     canvas.width = width
     canvas.height = height
-    canvas.getContext('2d').drawImage(bitmap, 0, 0)
+    canvas.getContext('2d', { willReadFrequently: true }).drawImage(bitmap, 0, 0)
     bitmap.close()
     return canvas.toDataURL('image/jpeg', qualita).split(',')[1]
   }


### PR DESCRIPTION
## Follow-up al PR #49

Il fix del PR #49 (createImageBitmap con resize nativo) non ha risolto il problema: una foto caricata da un dispositivo reale dopo il deploy di quel fix ha comunque prodotto una thumbnail corrotta (`docs/gallery/piante/fico-di-mare-1777384451612/1784803420404_thumb.jpg`, già rigenerata a mano su `main`), questa volta con un pattern a scacchiera invece delle strisce viste in precedenza — un artefatto diverso, ma della stessa natura (JPEG valido a livello di contenitore, contenuto pixel corrotto).

## Nuova ipotesi

I metadati EXIF della foto originale indicano un dispositivo con GPU MediaTek/Mali. Questa classe di corruzione (strisce, scacchiere, moiré) è la firma tipica di un bug di readback del canvas quando è accelerato via GPU su alcuni driver mobili — un problema documentato in Chromium/Android con `canvas.toDataURL()`/`toBlob()` su determinate GPU.

## Fix

Aggiunta l'opzione `{ willReadFrequently: true }` al contesto 2d del canvas in `ridimensiona()` (`useGalleria.js`), che forza il browser a usare un canvas non accelerato via GPU (software), evitando il percorso di codice interessato dal bug.

## Limiti di questa verifica

Non sono riuscito a riprodurre la corruzione nel mio ambiente di test (Chromium headless in sandbox) né con l'approccio precedente né con questo — il bug sembra specifico per GPU/driver del dispositivo reale. Questo fix è quindi basato su un workaround noto e documentato per questa classe di problema, non su una riproduzione diretta. Ti chiedo di verificarlo caricando una nuova foto da telefono dopo il merge e deploy, così possiamo confermare se risolve definitivamente.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_