### PR TITLE
Elimina anche la thumbnail quando si cancella una foto

### DIFF
--- a/src/composables/useGalleria.js
+++ b/src/composables/useGalleria.js
@@ -76,8 +76,25 @@ export function useGalleria() {
     return risultati.flat()
   }
 
-  function elimina(foto) {
-    return deleteFile(foto.path, foto.sha, `Elimina foto ${foto.nome}`)
+  // Elimina la foto e, se presente, anche la sua thumbnail gemella (stesso
+  // prefisso timestamp, esclusa da listaFoto perché è un dettaglio interno):
+  // senza questo passaggio la thumbnail resterebbe orfana nel repository.
+  // Il fallimento di questa pulizia non blocca l'eliminazione della foto,
+  // che è l'azione principale richiesta dall'utente.
+  async function elimina(foto) {
+    const risultato = await deleteFile(foto.path, foto.sha, `Elimina foto ${foto.nome}`)
+    if (foto.cartella && foto.cartella !== 'generale') {
+      try {
+        const ts = parseInt(foto.nome.split('_')[0])
+        const thumbNome = `${ts}_thumb.jpg`
+        const files = await listDir(`${FOLDER}/${foto.cartella}`)
+        const thumb = files.find(f => f.name === thumbNome)
+        if (thumb) await deleteFile(thumb.path, thumb.sha, `Elimina thumbnail ${thumbNome}`)
+      } catch {
+        // Vedi commento sopra.
+      }
+    }
+    return risultato
   }
 
   // Cancellazione best-effort di tutte le foto di una pianta (chiamata prima


### PR DESCRIPTION
## Problema

Cancellando una foto dalla galleria, la sua thumbnail gemella (`{ts}_thumb.jpg`) restava orfana nel repository: `elimina(foto)` cancellava solo il file originale passato dalla UI, mentre le thumbnail sono deliberatamente escluse da `listaFoto()` (sono un dettaglio interno usato solo per le anteprime nell'elenco piante, non fanno parte della galleria mostrata all'utente) e quindi non venivano mai considerate per l'eliminazione.

Trovato oggi ripulendo due thumbnail orfane rimaste da foto cancellate durante alcuni test di caricamento.

## Fix

`elimina()` ora, dopo aver cancellato la foto, cerca nella stessa cartella un file `{ts}_thumb.jpg` con lo stesso prefisso timestamp e lo elimina a sua volta. Come per la generazione delle thumbnail in `carica()`, è un'operazione best-effort: se fallisce non blocca l'eliminazione della foto, che resta l'azione principale.

## Test

`npm run build` completa senza errori.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_