### PR TITLE
Statusbar: mostra lo stato reale del repository, visibile anche su mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
     </div>
   </Transition>
 
-  <main style="max-width:920px;margin:0 auto;padding:28px 16px 80px;position:relative;z-index:1;">
+  <main class="app-main" style="max-width:920px;margin:0 auto;padding:28px 16px 80px;position:relative;z-index:1;">
     <RouterView v-slot="{ Component }">
       <Transition name="page" mode="out-in">
         <component :is="Component" />
@@ -39,3 +39,12 @@ const mostraBanner = ref(true)
 
 onMounted(() => store.caricaTutto())
 </script>
+
+<style scoped>
+/* Su mobile la statusbar si aggiunge sopra la BottomNav (vedi StatusBar.vue):
+   serve più spazio in fondo alla pagina perché il contenuto non finisca dietro
+   a entrambe. */
+@media (max-width: 640px) {
+  .app-main { padding-bottom: 128px; }
+}
+</style>

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -1,19 +1,63 @@
 <template>
-  <div class="statusbar">
-    <div style="display:flex;align-items:center;gap:8px;">
+  <div class="statusbar" :class="`stato-${statoEffettivo}`" :style="{ bottom: offsetInferiore + 'px' }">
+    <div style="display:flex;align-items:center;gap:8px;min-width:0;">
       <span class="dot-glow"></span>
-      <span style="font-size:12px;color:var(--ink-soft);">{{ store.loading ? 'Caricamento…' : 'Pronto' }}</span>
+      <span style="font-size:12px;color:var(--ink-soft);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ testoStato }}</span>
     </div>
-    <button class="btn btn-ghost" style="padding:5px 14px;font-size:11px;border-radius:8px;min-height:32px;"
-      @click="store.aggiorna()">
-      Aggiorna
+    <button class="btn btn-ghost" style="padding:5px 14px;font-size:11px;border-radius:8px;min-height:32px;flex-shrink:0;"
+      @click="onClick">
+      {{ repo.stato.value === 'nuova-versione' ? 'Ricarica' : 'Aggiorna' }}
     </button>
   </div>
 </template>
 
 <script setup>
+import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { useDatiStore } from '@/stores/dati'
+import { useRepoStatus } from '@/composables/useRepoStatus'
+
 const store = useDatiStore()
+const repo  = useRepoStatus()
+
+// Priorità: il caricamento iniziale dei dati locali copre lo stato del
+// repository (che nel frattempo può ben essere "aggiornato"), perché mentre
+// i JSON non sono ancora arrivati non ha senso mostrare altro.
+const statoEffettivo = computed(() => store.loading ? 'caricamento' : repo.stato.value)
+
+const testoStato = computed(() => ({
+  caricamento:        'Caricamento…',
+  sincronizzazione:   'Sincronizzazione in corso…',
+  'nuova-versione':   'Nuova versione disponibile',
+  aggiornato:         'Aggiornato',
+  sconosciuto:        'Pronto',
+}[statoEffettivo.value]))
+
+function onClick() {
+  if (repo.stato.value === 'nuova-versione') {
+    // Un commit già pubblicato può aver cambiato anche il codice dell'app
+    // (non solo i dati): ricaricare la pagina, non solo i JSON, garantisce
+    // di ottenere anche il bundle aggiornato.
+    window.location.reload()
+  } else {
+    store.aggiorna()
+  }
+}
+
+// Su schermi stretti la BottomNav occupa il fondo pagina: la statusbar deve
+// stare appena sopra, con un offset misurato dal vero elemento a schermo
+// (safe-area e altezza reale variano da dispositivo a dispositivo) invece
+// che da un valore fisso indovinato in CSS.
+const offsetInferiore = ref(0)
+function aggiornaOffset() {
+  const nav = document.querySelector('.bottom-nav')
+  const visibile = nav && getComputedStyle(nav).display !== 'none'
+  offsetInferiore.value = visibile ? nav.getBoundingClientRect().height : 0
+}
+onMounted(() => {
+  aggiornaOffset()
+  window.addEventListener('resize', aggiornaOffset)
+})
+onUnmounted(() => window.removeEventListener('resize', aggiornaOffset))
 </script>
 
 <style scoped>
@@ -23,6 +67,20 @@ const store = useDatiStore()
   backdrop-filter: blur(16px);
   border-top: 1px solid var(--cream-dark);
   display: flex; align-items: center; justify-content: space-between; padding: 0 16px;
+  gap: 10px;
 }
-@media (max-width: 640px) { .statusbar { display: none; } }
+@media (max-width: 640px) {
+  .statusbar { height: 38px; padding: 0 12px; }
+}
+
+.stato-sincronizzazione .dot-glow {
+  background: var(--gold); box-shadow: 0 0 6px rgba(224,184,74,0.7);
+  animation: statusbar-pulse 1.1s ease-in-out infinite;
+}
+.stato-nuova-versione .dot-glow { background: var(--rose); box-shadow: 0 0 6px rgba(204,110,110,0.7); }
+
+@keyframes statusbar-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
 </style>

--- a/src/composables/useRepoStatus.js
+++ b/src/composables/useRepoStatus.js
@@ -1,0 +1,71 @@
+// Stato del repository, non solo del fetch locale dei JSON: dice se una
+// modifica (da Claude Code, da un altro dispositivo, o dalla web app stessa)
+// è appena stata committata/pushata e sta ancora venendo pubblicata su
+// GitHub Pages, così l'utente sa perché non vede ancora un cambiamento
+// atteso invece di pensare che l'app sia bloccata o rotta.
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const OWNER    = 'ziabetta84'
+const REPO     = 'giardino'
+const WORKFLOW = 'deploy.yml'
+
+function headers() {
+  const token = localStorage.getItem('github_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+export function useRepoStatus() {
+  // 'sincronizzazione' → un commit su main non è ancora stato pubblicato
+  // 'nuova-versione'   → pubblicato, ma questa scheda ha ancora la build precedente
+  // 'aggiornato'        → questa scheda mostra l'ultima versione pubblicata
+  // 'sconosciuto'       → nessuna risposta ancora, o errore/rate-limit di rete
+  const stato = ref('sconosciuto')
+  let timer = null
+
+  async function controlla() {
+    try {
+      const [commitRes, runRes] = await Promise.all([
+        fetch(`https://api.github.com/repos/${OWNER}/${REPO}/commits/main`, { headers: headers() }),
+        fetch(`https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW}/runs?branch=main&per_page=1`, { headers: headers() }),
+      ])
+      if (!commitRes.ok || !runRes.ok) return  // errore temporaneo/rate-limit: mantiene l'ultimo stato noto
+
+      const ultimoCommit = (await commitRes.json()).sha
+      const ultimoRun = (await runRes.json()).workflow_runs?.[0]
+      const pubblicato = ultimoRun?.head_sha === ultimoCommit && ultimoRun?.status === 'completed'
+
+      if (!pubblicato) {
+        stato.value = 'sincronizzazione'
+      } else if (__APP_COMMIT__ && ultimoCommit !== __APP_COMMIT__) {
+        stato.value = 'nuova-versione'
+      } else {
+        stato.value = 'aggiornato'
+      }
+    } catch {
+      // Silenzioso: rete assente o irraggiungibile, riprova al giro successivo.
+    }
+  }
+
+  function onVisibilita() {
+    if (document.visibilityState === 'visible') controlla()
+  }
+
+  onMounted(() => {
+    controlla()
+    // Con token l'app ha 5000 richieste/ora (2 per controllo → ok anche
+    // frequente); senza token il limite anonimo è 60/ora, quindi un
+    // intervallo molto più largo per restare ampiamente sotto soglia.
+    const intervallo = localStorage.getItem('github_token') ? 20_000 : 180_000
+    timer = setInterval(() => {
+      if (document.visibilityState === 'visible') controlla()
+    }, intervallo)
+    document.addEventListener('visibilitychange', onVisibilita)
+  })
+
+  onUnmounted(() => {
+    if (timer) clearInterval(timer)
+    document.removeEventListener('visibilitychange', onVisibilita)
+  })
+
+  return { stato }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,8 +3,23 @@ import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { fileURLToPath, URL } from 'node:url'
+import { execSync } from 'node:child_process'
+
+// Commit su cui è basata questa build: confrontato a runtime con l'ultimo
+// commit su main per capire se la versione caricata è quella pubblicata
+// più di recente (vedi useRepoStatus.js / StatusBar.vue).
+function commitBuild() {
+  try {
+    return execSync('git rev-parse HEAD').toString().trim()
+  } catch {
+    return null
+  }
+}
 
 export default defineConfig({
+  define: {
+    __APP_COMMIT__: JSON.stringify(commitBuild()),
+  },
   plugins: [
     vue(),
     tailwindcss(),


### PR DESCRIPTION
## Motivazione

La statusbar in basso mostrava solo lo stato del fetch locale dei JSON (`Caricamento…`/`Pronto`), nascosta del tutto su mobile. Non rispondeva alla domanda reale: "una modifica (mia, di Claude, o da un altro dispositivo) è stata già committata/pushata e pubblicata, o è ancora in transito?"

## Cosa cambia

`useRepoStatus.js` (nuovo) confronta, via API GitHub pubblica:
- l'ultimo commit su `main`
- l'ultimo run del workflow `deploy.yml` per quel commit
- il commit su cui è basata la build attualmente caricata in questa scheda (iniettato a build time in `vite.config.js` via `git rev-parse HEAD`, esposto come `__APP_COMMIT__`)

Tre stati possibili nella barra:
- **Sincronizzazione in corso…** — il deploy per l'ultimo commit su main non è ancora completato
- **Nuova versione disponibile** — deploy completato, ma questa scheda ha ancora la build precedente; il bottone diventa "Ricarica" (ricarica l'intera pagina, non solo i dati, per prendere anche eventuali modifiche al codice)
- **Aggiornato** — tutto allineato

Il controllo avviene ogni 20s (con token GitHub salvato, limite 5000 richieste/ora) o ogni 3 minuti (senza token, per restare sotto il limite anonimo di 60/ora), solo mentre la scheda è visibile.

La barra è ora visibile anche su mobile (prima nascosta sotto i 640px), posizionata sopra la `BottomNav` con un offset misurato dal vero elemento a schermo (non un valore fisso, per restare corretta su qualsiasi dispositivo/safe-area).

## Test

- `npm run build` completa senza errori; verificato che `__APP_COMMIT__` viene iniettato correttamente con lo SHA del commit corrente.
- Verificato via Playwright, a schermo mobile (390×844), che la barra si posiziona esattamente sopra la BottomNav senza sovrapposizioni né spazi vuoti.
- Verificata la logica di calcolo dei tre stati in isolamento (test unitari su tutte le combinazioni commit/run/build).
- Verificati visivamente tutti e tre gli stati nell'interfaccia mockando le risposte dell'API GitHub (rete reale non affidabile in questo ambiente sandboxato per test ripetuti).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_