### PR TITLE
Fix parseGiorni: "settimane" veniva interpretato come "giorni"

### DIFF
--- a/src/components/SelettoreSpecie.vue
+++ b/src/components/SelettoreSpecie.vue
@@ -111,6 +111,7 @@
 import { ref, computed, watch } from 'vue'
 import { useDatiStore } from '@/stores/dati'
 import { useApi } from '@/composables/useApi'
+import { parseGiorni } from '@/composables/useCure'
 
 const props = defineProps({
   modelValue: { type: String, default: '' },
@@ -196,10 +197,13 @@ const manutenzioneNumeroIniziale = ref({
   calcio: { primavera: null, estate: null, autunno: null, inverno: null },
 })
 
+// Riusa la stessa logica di useCure.js (non una regex propria): un tempo
+// questo file ne teneva una copia separata che non riconosceva "settimane"
+// come unità, mostrando "2" invece di "14" per un valore come "ogni 2
+// settimane" — la stessa causa del bug poi trovato nel motore cure.
 function estraiGiorniPuliti(testo) {
   if (typeof testo === 'number') return testo
-  const m = String(testo || '').match(/(\d+)/)
-  return m ? parseInt(m[1], 10) : null
+  return parseGiorni(testo)
 }
 
 const nuovaSpecie = ref({ nome: '', nomeScientifico: '', descrizione: '', luce: '', acqua: '', terreno: '', alert: '', manutenzione: manutenzioneVuota() })

--- a/src/composables/useCure.js
+++ b/src/composables/useCure.js
@@ -12,10 +12,20 @@ export function stagione(data = new Date()) {
   return Object.entries(STAGIONE_MESI).find(([,mesi]) => mesi.includes(mese))?.[0] ?? 'estate'
 }
 
-function parseGiorni(testo) {
+// Riconosce l'unità dopo il numero (giorni/settimane/mesi): senza questo
+// controllo un testo come "ogni 2 settimane" veniva letto come "ogni 2
+// giorni", segnalando la cura scaduta quasi ogni giorno invece che ogni due
+// settimane. In un range ("ogni 2-3 settimane") prende il primo numero,
+// come già avviene per i range in giorni.
+export function parseGiorni(testo) {
   if (!testo) return null
-  const match = testo.match(/(\d+)/)
-  return match ? parseInt(match[1]) : null
+  const match = testo.match(/(\d+)(?:-\d+)?\s*(settiman\w*|mes[ei]\b|giorn\w*)?/i)
+  if (!match) return null
+  const numero = parseInt(match[1], 10)
+  const unita = (match[2] || '').toLowerCase()
+  if (unita.startsWith('settiman')) return numero * 7
+  if (unita.startsWith('mes')) return numero * 30
+  return numero
 }
 
 // Pioggia cumulata (oggi + domani) considerata sufficiente da sostituire un'irrigazione manuale


### PR DESCRIPTION
## Problema

`parseGiorni()` in `useCure.js` estraeva il primo numero trovato nel testo di manutenzione senza controllare l'unità che lo segue. Per un valore come `"ogni 2 settimane"` (concimazione orchidea e ~40 altre specie), il numero estratto era `2`, interpretato come "2 giorni" invece di "2 settimane" (14 giorni) — la concimazione risultava quindi scaduta quasi ogni giorno invece che ogni due settimane.

Il bug interessava **58 valori su ~40 specie diverse** (tutti quelli con "settimane" invece di "giorni" come unità in `manutenzione.concimazione`).

## Fix

`parseGiorni()` ora riconosce l'unità dopo il numero: "settimane" (×7) e "mesi" (×30), oltre a "giorni" (invariato). In un range (es. "ogni 2-3 settimane") prende il primo numero, come già avviene per i range in giorni.

La funzione è stata esportata da `useCure.js` e `SelettoreSpecie.vue` ora la riusa al posto di una propria regex quasi identica (`estraiGiorniPuliti`) che aveva lo stesso identico difetto — la duplicazione tra le due era proprio ciò che aveva permesso al bug di passare inosservato.

## Test

- `npm run build` completa senza errori.
- Confrontato il parsing vecchio vs nuovo su tutti gli 853 valori testuali del database: cambiano esattamente i 58 valori con "settimane" (nessuna regressione sugli altri 795).
- Verificato `valutaCura()` per la concimazione di un'orchidea reale: prima del fix avrebbe usato un intervallo di 2 giorni, dopo il fix usa correttamente 14 giorni.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XR4A8mQmjpRMC6CmhUzcqv)_